### PR TITLE
fix(deps): make zod a peerDep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.3-beta.1](https://github.com/koordinates/xstate-tree/compare/v1.1.2...v1.1.3-beta.1) (2022-08-18)
+
+
+### fix
+
+* **deps:** make zod a peerDep ([79d4ab2](https://github.com/koordinates/xstate-tree/commit/79d4ab2f26825ba6ee8240bbadee06ac48e59da3))
+
 ## [1.1.2](https://github.com/koordinates/xstate-tree/compare/v1.1.1...v1.1.2) (2022-08-08)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koordinates/xstate-tree",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@koordinates/xstate-tree",
-      "version": "1.1.2",
+      "version": "1.1.3-beta.1",
       "dependencies": {
         "@xstate/react": "3.0.0",
         "fast-memoize": "2.5.2",
@@ -18,8 +18,7 @@
         "react-dom": "18.1.0",
         "rxjs": "6.6.2",
         "tiny-emitter": "2.1.0",
-        "typescript": "4.7.3",
-        "zod": "3.17.3"
+        "typescript": "4.7.3"
       },
       "devDependencies": {
         "@microsoft/api-extractor": "7.28.4",
@@ -52,7 +51,8 @@
         "xstate": "4.32.0"
       },
       "peerDependencies": {
-        "xstate": ">= 4.20 < 5.0.0"
+        "xstate": ">= 4.20 < 5.0.0",
+        "zod": "3.x"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -17507,6 +17507,7 @@
       "version": "3.17.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
       "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -30591,7 +30592,8 @@
     "zod": {
       "version": "3.17.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
-      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg=="
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@koordinates/xstate-tree",
   "main": "lib/index.js",
   "types": "lib/xstate-tree.d.ts",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.1",
   "dependencies": {
     "@xstate/react": "3.0.0",
     "fast-memoize": "2.5.2",


### PR DESCRIPTION
Zod should be a peerDep so consumers of xstate-tree can have xstate-tree use the same Zod version
for ZodType compatability with routes