### PR TITLE
feat(xstate): update builders to use typegen states

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,5 +1,16 @@
 import React from "react";
-import type { EventObject, Typestate, StateMachine, Interpreter } from "xstate";
+import type {
+  EventObject,
+  Typestate,
+  StateMachine,
+  Interpreter,
+  TypegenConstraint,
+  TypegenEnabled,
+  TypegenMeta,
+  BaseActionObject,
+  ServiceMap,
+  ResolveTypegenMeta,
+} from "xstate";
 
 import { Slot } from "./slots";
 import {
@@ -20,19 +31,38 @@ type Selectors<TContext, TEvent extends EventObject, TSelectors, TStates> = (
  */
 export function buildSelectors<
   TContext,
+  TStateSchema,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext>,
-  TSelectors
+  TXstateActions extends BaseActionObject,
+  TServices extends ServiceMap,
+  TTypegen extends TypegenConstraint,
+  TSelectors,
+  TStates = TTypegen extends TypegenEnabled
+    ? TTypegen extends ResolveTypegenMeta<infer T, any, any, any>
+      ? T extends TypegenMeta
+        ? T["matchesStates"]
+        : never
+      : never
+    : TTypestate["value"]
 >(
-  __machine: StateMachine<TContext, any, TEvent, TTypestate, any, any, any>,
-  selectors: Selectors<TContext, TEvent, TSelectors, TTypestate["value"]>
+  __machine: StateMachine<
+    TContext,
+    TStateSchema,
+    TEvent,
+    TTypestate,
+    TXstateActions,
+    TServices,
+    TTypegen
+  >,
+  selectors: Selectors<TContext, TEvent, TSelectors, TStates>
 ): (
   ctx: TContext,
   canHandleEvent: (e: TEvent) => boolean,
-  inState: (state: TTypestate["value"]) => boolean,
-  currentState: TTypestate["value"]
+  inState: (state: TStates) => boolean,
+  currentState: TStates
 ) => TSelectors {
-  let lastState: TTypestate["value"] | undefined = undefined;
+  let lastState: TStates | undefined = undefined;
   let lastCachedResult: TSelectors | undefined = undefined;
   let lastCtxRef: TContext | undefined = undefined;
   return (ctx, canHandleEvent, inState, currentState) => {
@@ -62,14 +92,33 @@ export function buildSelectors<
  */
 export function buildActions<
   TContext,
+  TStateSchema,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext>,
+  TXstateActions extends BaseActionObject,
+  TServices extends ServiceMap,
+  TTypegen extends TypegenConstraint,
   TActions,
   TSelectors,
+  TStates = TTypegen extends TypegenEnabled
+    ? TTypegen extends ResolveTypegenMeta<infer T, any, any, any>
+      ? T extends TypegenMeta
+        ? T["matchesStates"]
+        : never
+      : never
+    : TTypestate["value"],
   TSend = (send: TEvent) => void
 >(
-  __machine: StateMachine<TContext, any, TEvent, TTypestate, any, any, any>,
-  __selectors: Selectors<TContext, TEvent, TSelectors, TTypestate["value"]>,
+  __machine: StateMachine<
+    TContext,
+    TStateSchema,
+    TEvent,
+    TTypestate,
+    TXstateActions,
+    TServices,
+    TTypegen
+  >,
+  __selectors: Selectors<TContext, TEvent, TSelectors, TStates>,
   actions: (send: TSend, selectors: TSelectors) => TActions
 ): (send: TSend, selectors: TSelectors) => TActions {
   let lastSelectorResult: TSelectors | undefined = undefined;
@@ -96,16 +145,35 @@ export function buildActions<
  */
 export function buildView<
   TContext,
+  TStateSchema,
   TEvent extends EventObject,
   TTypestate extends Typestate<TContext>,
+  TXstateActions extends BaseActionObject,
+  TServices extends ServiceMap,
+  TTypegen extends TypegenConstraint,
   TActions,
   TSelectors,
   TSlots extends readonly Slot[] = [],
-  TViewProps = ViewProps<TSelectors, TActions, TSlots, TTypestate["value"]>,
+  TStates = TTypegen extends TypegenEnabled
+    ? TTypegen extends ResolveTypegenMeta<infer T, any, any, any>
+      ? T extends TypegenMeta
+        ? T["matchesStates"]
+        : never
+      : never
+    : TTypestate["value"],
+  TViewProps = ViewProps<TSelectors, TActions, TSlots, TStates>,
   TSend = (send: TEvent) => void
 >(
-  __machine: StateMachine<TContext, any, TEvent, TTypestate, any, any, any>,
-  __selectors: Selectors<TContext, TEvent, TSelectors, TTypestate["value"]>,
+  __machine: StateMachine<
+    TContext,
+    TStateSchema,
+    TEvent,
+    TTypestate,
+    TXstateActions,
+    TServices,
+    TTypegen
+  >,
+  __selectors: Selectors<TContext, TEvent, TSelectors, TStates>,
   __actions: (send: TSend, selectors: TSelectors) => TActions,
   __slots: TSlots,
   view: React.ComponentType<TViewProps>

--- a/src/test-app/AppMachine.tsx
+++ b/src/test-app/AppMachine.tsx
@@ -20,47 +20,50 @@ type Context = {};
 type Events =
   | RoutingEvent<typeof homeRoute>
   | RoutingEvent<typeof settingsRoute>;
-type State =
-  | { value: "todos"; context: Context }
-  | { value: "otherScreen"; context: Context };
 const ScreenSlot = singleSlot("ScreenGoesHere");
 const slots = [ScreenSlot];
 const OtherMachine = () =>
   import("./OtherMachine").then(({ OtherMachine }) => OtherMachine);
-const AppMachine = createMachine<Context, Events, State>(
-  {
-    id: "app",
-    initial: "waitingForRoute",
-    on: {
-      GO_HOME: {
-        target: ".todos",
-        cond: (_ctx, e) => e.meta.indexEvent ?? false,
-      },
-      GO_SETTINGS: ".otherScreen",
-    },
-    states: {
-      waitingForRoute: {},
-      todos: {
-        invoke: {
-          id: ScreenSlot.getId(),
-          src: "TodosMachine",
+const AppMachine =
+  /** @xstate-layout N4IgpgJg5mDOIC5QEMAOqDEBxA8gfQAkcBZAUUVFQHtYBLAF1qoDsKQAPRAFgCYAaEAE9EPLgEYAdAE4ZUgBxcAzFxkBWGQDYAvloFpMuPAGVSAFVMBJAHJYjbanUYs2nBLwHCEY1QHZpsnxV1KUV1HV0QZioIODZ9CQB3ZAZaZigAMSoAJwAlKgBXejB7GhTnJA5uP1VFKQAGDVUNRTrWuQ9EOSl-GTlAn00B7Qj4+miaEscmVgrXHh4fDoRRVR6ZBrqZH3U5HT10CSp6AAswLKMAYyywMBnKUqc7yuWFpbEeDTXGppkxMTlhvtUJMyk9XP8lsMdEA */
+  createMachine(
+    {
+      tsTypes: {} as import("./AppMachine.typegen").Typegen0,
+      schema: { context: {} as Context, events: {} as Events },
+      id: "app",
+      initial: "waitingForRoute",
+      on: {
+        GO_HOME: {
+          cond: (_ctx, e) => e.meta.indexEvent ?? false,
+          target: ".todos",
+        },
+        GO_SETTINGS: {
+          target: ".otherScreen",
         },
       },
-      otherScreen: {
-        invoke: {
-          id: ScreenSlot.getId(),
-          src: "OtherMachine",
+      states: {
+        waitingForRoute: {},
+        todos: {
+          invoke: {
+            src: "TodosMachine",
+            id: ScreenSlot.getId(),
+          },
+        },
+        otherScreen: {
+          invoke: {
+            src: "OtherMachine",
+            id: ScreenSlot.getId(),
+          },
         },
       },
     },
-  },
-  {
-    services: {
-      TodosMachine: TodosMachine,
-      OtherMachine: lazy(OtherMachine),
-    },
-  }
-);
+    {
+      services: {
+        TodosMachine: TodosMachine,
+        OtherMachine: lazy(OtherMachine),
+      },
+    }
+  );
 
 const actions = buildActions(AppMachine, identity, () => ({}));
 

--- a/src/test-app/AppMachine.typegen.ts
+++ b/src/test-app/AppMachine.typegen.ts
@@ -1,0 +1,27 @@
+// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {
+    OtherMachine: "done.invoke.app.otherScreen:invocation[0]";
+    TodosMachine: "done.invoke.app.todos:invocation[0]";
+  };
+  missingImplementations: {
+    actions: never;
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {};
+  eventsCausingServices: {
+    OtherMachine: "GO_SETTINGS";
+    TodosMachine: "GO_HOME";
+  };
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: "otherScreen" | "todos" | "waitingForRoute";
+  tags: never;
+}

--- a/src/test-app/OtherMachine.tsx
+++ b/src/test-app/OtherMachine.tsx
@@ -21,7 +21,11 @@ declare global {
 type Events =
   | PickEvent<"DO_THE_THING" | "GO_TO_DO_THE_THING_STATE">
   | RoutingEvent<typeof settingsRoute>;
-const machine = createMachine<unknown, Events>({
+type States = {
+  value: "awaitingRoute";
+  context: any;
+};
+const machine = createMachine<unknown, Events, States>({
   id: "other",
   initial: "awaitingRoute",
   states: {

--- a/xstate-tree.api.md
+++ b/xstate-tree.api.md
@@ -18,7 +18,10 @@ import { default as React_2 } from 'react';
 import { ResolveTypegenMeta } from 'xstate';
 import { ServiceMap } from 'xstate';
 import { StateMachine } from 'xstate';
+import type { TypegenConstraint } from 'xstate';
 import { TypegenDisabled } from 'xstate';
+import type { TypegenEnabled } from 'xstate';
+import type { TypegenMeta } from 'xstate';
 import { Typestate } from 'xstate';
 import * as Z from 'zod';
 
@@ -46,7 +49,7 @@ export function broadcast(event: GlobalEvents): void;
 // Warning: (ae-forgotten-export) The symbol "Selectors" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function buildActions<TContext, TEvent extends EventObject, TTypestate extends Typestate<TContext>, TActions, TSelectors, TSend = (send: TEvent) => void>(__machine: StateMachine<TContext, any, TEvent, TTypestate, any, any, any>, __selectors: Selectors<TContext, TEvent, TSelectors, TTypestate["value"]>, actions: (send: TSend, selectors: TSelectors) => TActions): (send: TSend, selectors: TSelectors) => TActions;
+export function buildActions<TContext, TStateSchema, TEvent extends EventObject, TTypestate extends Typestate<TContext>, TXstateActions extends BaseActionObject, TServices extends ServiceMap, TTypegen extends TypegenConstraint, TActions, TSelectors, TStates = TTypegen extends TypegenEnabled ? TTypegen extends ResolveTypegenMeta<infer T, any, any, any> ? T extends TypegenMeta ? T["matchesStates"] : never : never : TTypestate["value"], TSend = (send: TEvent) => void>(__machine: StateMachine<TContext, TStateSchema, TEvent, TTypestate, TXstateActions, TServices, TTypegen>, __selectors: Selectors<TContext, TEvent, TSelectors, TStates>, actions: (send: TSend, selectors: TSelectors) => TActions): (send: TSend, selectors: TSelectors) => TActions;
 
 // @public (undocumented)
 export function buildCreateRoute(history: XstateTreeHistory, basePath: string): {
@@ -105,7 +108,7 @@ export function buildRootComponent<TContext, TEvent extends EventObject, TTypeSt
 };
 
 // @public (undocumented)
-export function buildSelectors<TContext, TEvent extends EventObject, TTypestate extends Typestate<TContext>, TSelectors>(__machine: StateMachine<TContext, any, TEvent, TTypestate, any, any, any>, selectors: Selectors<TContext, TEvent, TSelectors, TTypestate["value"]>): (ctx: TContext, canHandleEvent: (e: TEvent) => boolean, inState: (state: TTypestate["value"]) => boolean, currentState: TTypestate["value"]) => TSelectors;
+export function buildSelectors<TContext, TStateSchema, TEvent extends EventObject, TTypestate extends Typestate<TContext>, TXstateActions extends BaseActionObject, TServices extends ServiceMap, TTypegen extends TypegenConstraint, TSelectors, TStates = TTypegen extends TypegenEnabled ? TTypegen extends ResolveTypegenMeta<infer T, any, any, any> ? T extends TypegenMeta ? T["matchesStates"] : never : never : TTypestate["value"]>(__machine: StateMachine<TContext, TStateSchema, TEvent, TTypestate, TXstateActions, TServices, TTypegen>, selectors: Selectors<TContext, TEvent, TSelectors, TStates>): (ctx: TContext, canHandleEvent: (e: TEvent) => boolean, inState: (state: TStates) => boolean, currentState: TStates) => TSelectors;
 
 // Warning: (ae-internal-missing-underscore) The name "buildStorybookComponent" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -120,7 +123,7 @@ export function buildTestRootComponent<TContext, TEvent extends EventObject, TTy
 };
 
 // @public (undocumented)
-export function buildView<TContext, TEvent extends EventObject, TTypestate extends Typestate<TContext>, TActions, TSelectors, TSlots extends readonly Slot[] = [], TViewProps = ViewProps<TSelectors, TActions, TSlots, TTypestate["value"]>, TSend = (send: TEvent) => void>(__machine: StateMachine<TContext, any, TEvent, TTypestate, any, any, any>, __selectors: Selectors<TContext, TEvent, TSelectors, TTypestate["value"]>, __actions: (send: TSend, selectors: TSelectors) => TActions, __slots: TSlots, view: React_2.ComponentType<TViewProps>): React_2.ComponentType<TViewProps>;
+export function buildView<TContext, TStateSchema, TEvent extends EventObject, TTypestate extends Typestate<TContext>, TXstateActions extends BaseActionObject, TServices extends ServiceMap, TTypegen extends TypegenConstraint, TActions, TSelectors, TSlots extends readonly Slot[] = [], TStates = TTypegen extends TypegenEnabled ? TTypegen extends ResolveTypegenMeta<infer T, any, any, any> ? T extends TypegenMeta ? T["matchesStates"] : never : never : TTypestate["value"], TViewProps = ViewProps<TSelectors, TActions, TSlots, TStates>, TSend = (send: TEvent) => void>(__machine: StateMachine<TContext, TStateSchema, TEvent, TTypestate, TXstateActions, TServices, TTypegen>, __selectors: Selectors<TContext, TEvent, TSelectors, TStates>, __actions: (send: TSend, selectors: TSelectors) => TActions, __slots: TSlots, view: React_2.ComponentType<TViewProps>): React_2.ComponentType<TViewProps>;
 
 // Warning: (ae-forgotten-export) The symbol "InferViewProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "PropsOf" needs to be exported by the entry point index.d.ts


### PR DESCRIPTION
Currently, the only way of specifying states is via type states, which are not used with typegen.

This means that the argument for `inState` ends up being `any` which is not great.

This commit updates the builder functions to extract the typegen'd states from the supplied state machine if it is using typegen, reverting to type states otherwise.

So now the `inState` arguments to the selectors/views will now be typegen aware.