### PR TITLE
perf(actions): do not re-create actions object

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -91,8 +91,8 @@ export function buildSelectors<
  * - `send` - the interpreters send function, which can be used to send events to the machine
  * - `selectors` - the output of the selectors function from {@link buildSelectors}
  *
- * The resulting action function has memoization. It will return the same value until the
- * selectors reference changes or the send reference changes
+ * The resulting action function will only be called once per invocation of a machine.
+ * The selectors are passed in as a proxy to always read the latest selector value
  *
  * @param machine - The machine to create the actions for
  * @param selectors - The selectors function
@@ -109,26 +109,7 @@ export function buildActions<
   __selectors: TSelectors,
   actions: (send: TSend, selectors: OutputFromSelector<TSelectors>) => TActions
 ): (send: TSend, selectors: OutputFromSelector<TSelectors>) => TActions {
-  let lastSelectorResult: OutputFromSelector<TSelectors> | undefined =
-    undefined;
-  let lastCachedResult: TActions | undefined = undefined;
-  let lastSendReference: TSend | undefined = undefined;
-
-  return (send, selectors) => {
-    if (
-      lastSelectorResult === selectors &&
-      lastCachedResult !== undefined &&
-      lastSendReference === send
-    ) {
-      return lastCachedResult;
-    }
-
-    lastCachedResult = actions(send, selectors);
-    lastSelectorResult = selectors;
-    lastSendReference = send;
-
-    return lastCachedResult;
-  };
+  return actions;
 }
 
 /**

--- a/src/tests/actionsGetUpdatedSelectors.spec.tsx
+++ b/src/tests/actionsGetUpdatedSelectors.spec.tsx
@@ -1,0 +1,82 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { assign, createMachine } from "xstate";
+
+import {
+  buildActions,
+  buildSelectors,
+  buildView,
+  buildXStateTreeMachine,
+} from "../builders";
+import { delay } from "../utils";
+import { buildRootComponent } from "../xstateTree";
+
+describe("actions accessing selectors", () => {
+  let actionsCallCount = 0;
+  type Events = { type: "SET_COUNT"; count: number };
+  type Context = { count: number };
+  const machine = createMachine<Context, Events>({
+    context: {
+      count: 0,
+    },
+    on: {
+      SET_COUNT: {
+        actions: assign({ count: (_, event) => event.count }),
+      },
+    },
+    initial: "foo",
+    states: {
+      foo: {},
+    },
+  });
+
+  const selectors = buildSelectors(machine, (ctx) => ({ count: ctx.count }));
+  const actions = buildActions(machine, selectors, (send, selectors) => {
+    actionsCallCount++;
+    return {
+      incrementCount() {
+        send({ type: "SET_COUNT", count: selectors.count + 1 });
+      },
+    };
+  });
+
+  const view = buildView(
+    machine,
+    selectors,
+    actions,
+    [],
+    ({ selectors, actions }) => {
+      return (
+        <button onClick={actions.incrementCount}>{selectors.count}</button>
+      );
+    }
+  );
+
+  const Root = buildRootComponent(
+    buildXStateTreeMachine(machine, {
+      actions,
+      selectors,
+      slots: [],
+      view,
+    })
+  );
+
+  it("gets the most up to date selectors value without re-creating the action functions", async () => {
+    const { getByRole, rerender } = render(<Root />);
+
+    await delay(10);
+    rerender(<Root />);
+
+    const button = getByRole("button");
+
+    userEvent.click(button);
+    await delay();
+    expect(button).toHaveTextContent("1");
+
+    userEvent.click(button);
+    await delay();
+    expect(button).toHaveTextContent("2");
+    expect(actionsCallCount).toBe(1);
+  });
+});


### PR DESCRIPTION
This behaviour caused problems if one of the action functions was used in something like a React `useEffect`.
Since the reference to the function changes every time the machine state changes.

This could lead to an infinite loop.

Instead pass a proxy that references the latest selector values to the actions function. This way it can be created only once when the machines view is first rendered

Fixes Improve action handling #2