### PR TITLE
feat(routing): composable dynamic routes

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = { 
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0]
+  }
+};

--- a/examples/todomvc/routes.ts
+++ b/examples/todomvc/routes.ts
@@ -4,14 +4,17 @@ import { createBrowserHistory } from "history";
 export const history: XstateTreeHistory = createBrowserHistory();
 const createRoute = buildCreateRoute(history, "/");
 
-export const allTodos = createRoute.staticRoute()("/", "SHOW_ALL_TODOS");
-export const activeTodos = createRoute.staticRoute()(
-  "/active",
-  "SHOW_ACTIVE_TODOS"
-);
-export const completedTodos = createRoute.staticRoute()(
-  "/completed",
-  "SHOW_COMPLETED_TODOS"
-);
+export const allTodos = createRoute.simpleRoute()({
+  url: "/",
+  event: "SHOW_ALL_TODOS",
+});
+export const activeTodos = createRoute.simpleRoute()({
+  url: "/active",
+  event: "SHOW_ACTIVE_TODOS",
+});
+export const completedTodos = createRoute.simpleRoute()({
+  url: "/completed",
+  event: "SHOW_COMPLETED_TODOS",
+});
 
 export const routes = [allTodos, activeTodos, completedTodos];

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "test-examples": "tsc --noEmit",
     "todomvc": "vite dev",
     "build": "rimraf lib && rimraf out && tsc -p tsconfig.build.json",
-    "build:watch": "tsc -p tsconfig.build.json -w",
+    "build:watch": "tsc -p tsconfig.json -w",
     "api-extractor": "api-extractor run",
     "release": "semantic-release",
     "commitlint": "commitlint --edit"

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ export {
   type Routing404Event,
   type StyledLink,
   type ArgumentsForRoute,
-  type Options,
   type Params,
   type Query,
   type Meta,

--- a/src/routing/createRoute/createRoute.spec.ts
+++ b/src/routing/createRoute/createRoute.spec.ts
@@ -2,7 +2,7 @@ import { createMemoryHistory } from "history";
 import * as Z from "zod";
 
 import { XstateTreeHistory } from "../../types";
-import { assertIsDefined } from "../../utils";
+import { assert } from "../../utils";
 
 import { buildCreateRoute } from "./createRoute";
 
@@ -11,52 +11,49 @@ const createRoute = buildCreateRoute(hist, "/");
 
 describe("createRoute", () => {
   describe("createRoute.dynamicRoute", () => {
-    const dynamicRoute = createRoute.dynamicRoute({
-      params: Z.object({
-        foo: Z.string(),
-      }),
-    })({
+    const dynamicRoute = createRoute.route()({
       event: "GO_FOO",
-      matches: (url, _search) => {
-        if (url === "/foo") {
+      matcher: (url, _search) => {
+        if (url === "/foo/") {
           return {
             params: {
               foo: "foo",
             },
+            matchLength: 5,
           };
         }
 
         return false;
       },
-      reverse: ({ params }) => {
+      reverser: ({ params }) => {
         return "/foo/" + params?.foo;
       },
+      paramsSchema: Z.object({
+        foo: Z.string(),
+      }),
     });
 
     it("uses the routes matching function to determine if there is a match", () => {
       expect(dynamicRoute.matches("/foo", "")).toEqual({
         type: "GO_FOO",
         params: { foo: "foo" },
-        originalUrl: "/foo",
+        query: {},
+        originalUrl: "/foo/",
       });
 
-      expect(dynamicRoute.matches("/foo/bar", "")).toBe(undefined);
+      expect(dynamicRoute.matches("/foo/bar/", "")).toBe(false);
     });
 
     it("can get a url out of the route with reverse", () => {
-      expect(dynamicRoute.reverse({ params: { foo: "bar" } })).toBe("/foo/bar");
+      expect(dynamicRoute.reverse({ params: { foo: "bar" } })).toBe(
+        "/foo/bar/"
+      );
     });
   });
 
-  describe("createRoute.staticRoute", () => {
-    it("returns a route object with appropriate fields set", () => {
-      const route = createRoute.staticRoute()("/foo", "GO_FOO");
-
-      expect(route.url).toEqual("/foo/");
-    });
-
+  describe("createRoute.simpleRoute", () => {
     it("attaches the history/basePath arguments supplied to createCreateRoute to the route", () => {
-      const route = createRoute.staticRoute()("/foo", "GO_FOO");
+      const route = createRoute.simpleRoute()({ url: "/foo", event: "GO_FOO" });
 
       expect(route.basePath).toBe("/");
       expect(route.history).toBe(hist);
@@ -68,12 +65,14 @@ describe("createRoute", () => {
           const schema = Z.object({
             fooId: Z.string(),
           });
-          const route = createRoute.staticRoute()("/foo/:fooId", "GO_FOO", {
-            params: schema,
+          const route = createRoute.simpleRoute()({
+            url: "/foo/:fooId",
+            event: "GO_FOO",
+            paramsSchema: schema,
           });
 
           const match = route.matches("/foo/123", "");
-          assertIsDefined(match);
+          assert(match !== false);
           // Testing that the types are correct
           const _dummyParams: Z.TypeOf<typeof schema> = match.params;
 
@@ -85,10 +84,14 @@ describe("createRoute", () => {
         it("merges the parent routes meta type into the routes meta type, including the SharedMeta type", () => {
           type ParentMeta = { foo: string };
           type ChildMeta = { bar: string };
-          const parent = createRoute.staticRoute()("/foo", "GO_FOO", {
+          const parent = createRoute.simpleRoute()({
+            url: "/foo",
+            event: "GO_FOO",
             meta: {} as ParentMeta,
           });
-          const child = createRoute.staticRoute(parent)("/bar", "GO_BAR", {
+          const child = createRoute.simpleRoute(parent)({
+            url: "/bar",
+            event: "GO_BAR",
             meta: {} as ChildMeta,
           });
 
@@ -109,26 +112,22 @@ describe("createRoute", () => {
           const parentSchema = Z.object({
             barId: Z.string(),
           });
-          const parentRoute = createRoute.staticRoute()(
-            "/bar/:barId",
-            "GO_BAR",
-            {
-              params: parentSchema,
-            }
-          );
+          const parentRoute = createRoute.simpleRoute()({
+            url: "/bar/:barId",
+            event: "GO_BAR",
+            paramsSchema: parentSchema,
+          });
           const SubSchema = Z.object({
             fooId: Z.string(),
           });
-          const route = createRoute.staticRoute(parentRoute)(
-            "/foo/:fooId",
-            "GO_FOO",
-            {
-              params: SubSchema,
-            }
-          );
+          const route = createRoute.simpleRoute(parentRoute)({
+            url: "/foo/:fooId",
+            event: "GO_FOO",
+            paramsSchema: SubSchema,
+          });
 
           const match = route.matches("/bar/456/foo/123", "");
-          assertIsDefined(match);
+          assert(match !== false);
           const mergedSchema = parentSchema.merge(SubSchema);
           // Testing that the types are correct
           const _dummyParams: Z.TypeOf<typeof mergedSchema> = match.params;
@@ -137,36 +136,32 @@ describe("createRoute", () => {
         });
 
         it("does not merge the query schema of the parent route", () => {
-          const parentRoute = createRoute.staticRoute()(
-            "/bar/:barId",
-            "GO_BAR",
-            {
-              params: Z.object({
-                barId: Z.string(),
-              }),
-              query: Z.object({
-                someFilter: Z.string(),
-              }),
-            }
-          );
-          const route = createRoute.staticRoute(parentRoute)(
-            "/foo/:fooId",
-            "GO_FOO",
-            {
-              params: Z.object({
-                fooId: Z.string(),
-              }),
-              query: Z.object({
-                someOtherFilter: Z.string(),
-              }),
-            }
-          );
+          const parentRoute = createRoute.simpleRoute()({
+            url: "/bar/:barId",
+            event: "GO_BAR",
+            paramsSchema: Z.object({
+              barId: Z.string(),
+            }),
+            querySchema: Z.object({
+              someFilter: Z.string(),
+            }),
+          });
+          const route = createRoute.simpleRoute(parentRoute)({
+            url: "/foo/:fooId",
+            event: "GO_FOO",
+            paramsSchema: Z.object({
+              fooId: Z.string(),
+            }),
+            querySchema: Z.object({
+              someOtherFilter: Z.string(),
+            }),
+          });
 
           const match = route.matches(
             "/bar/456/foo/123",
             "?someOtherFilter=foo"
           );
-          assertIsDefined(match);
+          assert(match !== false);
 
           expect(match.query).toEqual({ someOtherFilter: "foo" });
         });
@@ -175,17 +170,18 @@ describe("createRoute", () => {
           const parentSchema = Z.object({
             barId: Z.string(),
           });
-          const parentRoute = createRoute.staticRoute()(
-            "/bar/:barId",
-            "GO_BAR",
-            {
-              params: parentSchema,
-            }
-          );
-          const route = createRoute.staticRoute(parentRoute)("/foo", "GO_FOO");
+          const parentRoute = createRoute.simpleRoute()({
+            url: "/bar/:barId",
+            event: "GO_BAR",
+            paramsSchema: parentSchema,
+          });
+          const route = createRoute.simpleRoute(parentRoute)({
+            url: "/foo",
+            event: "GO_FOO",
+          });
 
           const match = route.matches("/bar/456/foo", "");
-          assertIsDefined(match);
+          assert(match !== false);
           // Testing that the types are correct
           const _dummyParams: Z.TypeOf<typeof parentSchema> = match.params;
 
@@ -195,19 +191,21 @@ describe("createRoute", () => {
     });
 
     describe("matches", () => {
-      const route = createRoute.staticRoute()("/bar/:barId/", "GO_BAR", {
-        params: Z.object({
+      const route = createRoute.simpleRoute()({
+        url: "/bar/:barId/",
+        event: "GO_BAR",
+        paramsSchema: Z.object({
           barId: Z.string().refine((v) => v.startsWith("abc")),
         }),
-        query: Z.object({
+        querySchema: Z.object({
           someFilter: Z.string()
             .refine((v) => v.startsWith("abc"))
             .optional(),
         }),
       });
 
-      it("returns undefined if the url does not match the route", () => {
-        expect(route.matches("/foo", "")).toBeUndefined();
+      it("returns false if the url does not match the route", () => {
+        expect(route.matches("/foo", "")).toBe(false);
       });
 
       it("throws an error if the params matched by the route do not match the schema", () => {
@@ -221,14 +219,17 @@ describe("createRoute", () => {
       });
 
       it("works with baseRoutes ending with / and routes starting with /", () => {
-        const subRoute = createRoute.staticRoute(route)("/sub", "GO_SUB_ROUTE");
+        const subRoute = createRoute.simpleRoute(route)({
+          url: "/sub",
+          event: "GO_SUB_ROUTE",
+        });
 
         expect(subRoute.matches("/bar/abc/sub", "")).toBeDefined();
       });
 
       it("returns the matched params/query parameters from the url", () => {
         const match = route.matches("/bar/abc/", "?someFilter=abc");
-        assertIsDefined(match);
+        assert(match !== false);
 
         expect(match.params).toEqual({
           barId: "abc",
@@ -240,23 +241,31 @@ describe("createRoute", () => {
 
       it("returns the original url + query string", () => {
         const match = route.matches("/bar/abc/", "?someFilter=abc");
-        assertIsDefined(match);
+        assert(match !== false);
 
         expect(match.originalUrl).toBe("/bar/abc/?someFilter=abc");
       });
 
       it("sets the type field to the routes event property", () => {
         const match = route.matches("/bar/abc/", "?someFilter=abc");
-        assertIsDefined(match);
+        assert(match !== false);
 
         expect(match.type).toBe("GO_BAR");
+      });
+
+      it("does not match if there is any remaining part of the URL after matching the route", () => {
+        const match = route.matches("/bar/abc/baz/", "?someFilter=abc");
+
+        expect(match).toBe(false);
       });
     });
 
     describe("navigate", () => {
       it("requires the route arguments", () => {
-        const route = createRoute.staticRoute()("/foo/:fooId", "GO_FOO", {
-          params: Z.object({
+        const route = createRoute.simpleRoute()({
+          url: "/foo/:fooId",
+          event: "GO_FOO",
+          paramsSchema: Z.object({
             fooId: Z.string(),
           }),
         });
@@ -267,11 +276,13 @@ describe("createRoute", () => {
       });
 
       it("allows you to omit either params/query if you supply the other but both are fully optional objects", () => {
-        const route = createRoute.staticRoute()("/foo/:fooId", "GO_FOO", {
-          params: Z.object({
+        const route = createRoute.simpleRoute()({
+          url: "/foo/:fooId",
+          event: "GO_FOO",
+          paramsSchema: Z.object({
             fooId: Z.string().optional(),
           }),
-          query: Z.object({
+          querySchema: Z.object({
             bar: Z.string().optional(),
           }),
         });
@@ -282,11 +293,13 @@ describe("createRoute", () => {
       });
 
       it("allows you to omit either optional params/query if the other is required", () => {
-        const route = createRoute.staticRoute()("/foo/:fooId", "GO_FOO", {
-          params: Z.object({
+        const route = createRoute.simpleRoute()({
+          url: "/foo/:fooId",
+          event: "GO_FOO",
+          paramsSchema: Z.object({
             fooId: Z.string(),
           }),
-          query: Z.object({
+          querySchema: Z.object({
             bar: Z.string().optional(),
           }),
         });
@@ -301,11 +314,13 @@ describe("createRoute", () => {
         const spy = jest.fn();
         hist.push = spy as any;
         const createRoute = buildCreateRoute(hist, "/");
-        const route = createRoute.staticRoute()("/foo/:fooId", "GO_FOO", {
-          params: Z.object({
+        const route = createRoute.simpleRoute()({
+          url: "/foo/:fooId",
+          event: "GO_FOO",
+          paramsSchema: Z.object({
             fooId: Z.string(),
           }),
-          query: Z.object({
+          querySchema: Z.object({
             bar: Z.string().optional(),
           }),
         });
@@ -321,11 +336,13 @@ describe("createRoute", () => {
         const spy = jest.fn();
         hist.replace = spy as any;
         const createRoute = buildCreateRoute(hist, "/");
-        const route = createRoute.staticRoute()("/foo/:fooId", "GO_FOO", {
-          params: Z.object({
+        const route = createRoute.simpleRoute()({
+          url: "/foo/:fooId",
+          event: "GO_FOO",
+          paramsSchema: Z.object({
             fooId: Z.string(),
           }),
-          query: Z.object({
+          querySchema: Z.object({
             bar: Z.string().optional(),
           }),
         });
@@ -342,14 +359,19 @@ describe("createRoute", () => {
 
     describe("reverse", () => {
       it("returns the routes url if the route takes no params/query", () => {
-        const route = createRoute.staticRoute()("/foo", "GO_FOO");
+        const route = createRoute.simpleRoute()({
+          url: "/foo",
+          event: "GO_FOO",
+        });
 
         expect(route.reverse()).toBe("/foo/");
       });
 
       it("plugs the route holes with params if present", () => {
-        const route = createRoute.staticRoute()("/foo/:fooId", "GO_FOO", {
-          params: Z.object({
+        const route = createRoute.simpleRoute()({
+          url: "/foo/:fooId",
+          event: "GO_FOO",
+          paramsSchema: Z.object({
             fooId: Z.string(),
           }),
         });
@@ -358,11 +380,13 @@ describe("createRoute", () => {
       });
 
       it("plugs the route holes with params and includes query string if present", () => {
-        const route = createRoute.staticRoute()("/foo/:fooId", "GO_FOO", {
-          params: Z.object({
+        const route = createRoute.simpleRoute()({
+          url: "/foo/:fooId",
+          event: "GO_FOO",
+          paramsSchema: Z.object({
             fooId: Z.string(),
           }),
-          query: Z.object({
+          querySchema: Z.object({
             someFilter: Z.string(),
           }),
         });
@@ -374,15 +398,30 @@ describe("createRoute", () => {
           })
         ).toBe("/foo/123/?someFilter=123");
       });
+
+      it("handles parent routes", () => {
+        const parentRoute = createRoute.simpleRoute()({
+          url: "/foo",
+          event: "GO_FOO",
+        });
+        const childRoute = createRoute.simpleRoute(parentRoute)({
+          url: "/bar",
+          event: "GO_BAR",
+        });
+
+        expect(childRoute.reverse()).toBe("/foo/bar/");
+      });
     });
 
     describe("getEvent", () => {
       it("returns an event suitable for broadcasting", () => {
-        const route = createRoute.staticRoute()("/foo/:fooId", "GO_FOO", {
-          params: Z.object({
+        const route = createRoute.simpleRoute()({
+          url: "/foo/:fooId",
+          event: "GO_FOO",
+          paramsSchema: Z.object({
             fooId: Z.string(),
           }),
-          query: Z.object({
+          querySchema: Z.object({
             someFilter: Z.string(),
           }),
         });
@@ -403,13 +442,19 @@ describe("createRoute", () => {
 
     describe("routing functions for routes with no meta/params/query", () => {
       it("does not require any arguments to be supplied", () => {
-        const route = createRoute.staticRoute()("/foo", "GO_FOO");
+        const route = createRoute.simpleRoute()({
+          url: "/foo",
+          event: "GO_FOO",
+        });
 
         route.navigate();
       });
 
       it("allows you to optionally pass the shared meta info", () => {
-        const route = createRoute.staticRoute()("/foo", "GO_FOO");
+        const route = createRoute.simpleRoute()({
+          url: "/foo",
+          event: "GO_FOO",
+        });
 
         route.navigate({ meta: { doNotNotifyReactRouter: true } });
       });

--- a/src/routing/createRoute/index.ts
+++ b/src/routing/createRoute/index.ts
@@ -6,7 +6,6 @@ export {
   type RouteParams,
   type RouteMeta,
   type ArgumentsForRoute,
-  type Options,
   type Params,
   type Query,
   type Meta,

--- a/src/routing/handleLocationChange/handleLocationChange.spec.ts
+++ b/src/routing/handleLocationChange/handleLocationChange.spec.ts
@@ -8,8 +8,8 @@ import { RoutingEvent } from "../routingEvent";
 import { handleLocationChange, Routing404Event } from "./handleLocationChange";
 
 const createRoute = buildCreateRoute(createMemoryHistory(), "/");
-const foo = createRoute.staticRoute()("/foo", "GO_FOO");
-const bar = createRoute.staticRoute(foo)("/bar", "GO_BAR");
+const foo = createRoute.simpleRoute()({ url: "/foo", event: "GO_FOO" });
+const bar = createRoute.simpleRoute(foo)({ url: "/bar", event: "GO_BAR" });
 const routes = [foo, bar];
 describe("handleLocationChange", () => {
   const broadcastEvents: any[] = [];

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -6,7 +6,6 @@ export {
   type RouteMeta,
   type RouteArguments,
   type ArgumentsForRoute,
-  type Options,
   type Params,
   type Query,
   type Meta,

--- a/src/routing/joinRoutes.spec.ts
+++ b/src/routing/joinRoutes.spec.ts
@@ -2,18 +2,18 @@ import { joinRoutes } from "./joinRoutes";
 
 describe("joinRoutes", () => {
   it("joins the two routes together", () => {
-    expect(joinRoutes("/foo", "/bar")).toBe("/foo/bar");
+    expect(joinRoutes("/foo", "/bar")).toBe("/foo/bar/");
   });
 
   it("handles base routes that end with a slash", () => {
-    expect(joinRoutes("/foo/", "/bar")).toBe("/foo/bar");
+    expect(joinRoutes("/foo/", "/bar")).toBe("/foo/bar/");
   });
 
   it("handles routes that do not begin with a slash", () => {
-    expect(joinRoutes("/foo", "bar")).toBe("/foo/bar");
+    expect(joinRoutes("/foo", "bar")).toBe("/foo/bar/");
   });
 
   it("handles baseRoutes that end with slash and routes that start with slash", () => {
-    expect(joinRoutes("/foo/", "/bar")).toBe("/foo/bar");
+    expect(joinRoutes("/foo/", "/bar")).toBe("/foo/bar/");
   });
 });

--- a/src/routing/joinRoutes.ts
+++ b/src/routing/joinRoutes.ts
@@ -2,5 +2,5 @@ export function joinRoutes(base: string, route: string): string {
   const realBase = base.endsWith("/") ? base.slice(0, -1) : base;
   const realRoute = route.startsWith("/") ? route : `/${route}`;
 
-  return realBase + realRoute;
+  return realBase + (realRoute.endsWith("/") ? realRoute : `${realRoute}/`);
 }

--- a/src/routing/matchRoute/matchRoute.spec.ts
+++ b/src/routing/matchRoute/matchRoute.spec.ts
@@ -1,19 +1,23 @@
 import { createMemoryHistory } from "history";
 import * as Z from "zod";
 
-import { buildCreateRoute } from "../createRoute";
+import { AnyRoute, buildCreateRoute } from "../createRoute";
 
 import { matchRoute } from "./matchRoute";
 
 const hist = createMemoryHistory<{ meta?: unknown }>();
 const createRoute = buildCreateRoute(hist, "/");
 describe("matchRoute", () => {
-  const route1 = createRoute.staticRoute()("/route1", "ROUTE_1");
-  const route2 = createRoute.staticRoute()("/route2", "ROUTE_2", {
-    query: Z.object({ foo: Z.number() }),
+  const route1 = createRoute.simpleRoute()({ url: "/route1", event: "ROUTE_1" });
+  const route2 = createRoute.simpleRoute()({
+    url: "/route2",
+    event: "ROUTE_2",
+    querySchema: Z.object({ foo: Z.number() }),
   });
-  const route3 = createRoute.staticRoute()("/route3/:foo", "ROUTE_3", {
-    params: Z.object({
+  const route3 = createRoute.simpleRoute()({
+    url: "/route3/:foo",
+    event: "ROUTE_3",
+    paramsSchema: Z.object({
       foo: Z.string(),
     }),
   });

--- a/src/routing/matchRoute/matchRoute.ts
+++ b/src/routing/matchRoute/matchRoute.ts
@@ -1,4 +1,4 @@
-import { AnyRoute, Route } from "../createRoute";
+import { Route } from "../createRoute";
 import { RoutingEvent } from "../routingEvent";
 
 type Return<TRoutes extends Route<any, any, any, any>[]> =
@@ -29,7 +29,7 @@ export function matchRoute<TRoutes extends Route<any, any, any, any>[]>(
   })();
 
   const [matchingRoute, event] = routes
-    .map((route): [AnyRoute | Error | undefined, undefined | RoutingEvent<any>] => {
+    .map((route): [Route<any, any, any, any> | Error | undefined, undefined | RoutingEvent<any>] => {
       try {
         const match = route.matches(realPath, search);
         if (match) {

--- a/src/routing/useHref.spec.ts
+++ b/src/routing/useHref.spec.ts
@@ -6,8 +6,10 @@ import { useHref } from "./useHref";
 
 const hist = createMemoryHistory<{ meta?: unknown }>();
 const createRoute = buildCreateRoute(hist, "/foo");
-const route = createRoute.staticRoute()("/bar/:type(valid)", "GO_BAR", {
-  params: Z.object({
+const route = createRoute.simpleRoute()({
+  url: "/bar/:type(valid)",
+  event: "GO_BAR",
+  paramsSchema: Z.object({
     type: Z.literal("valid"),
   }),
 });

--- a/src/test-app/AppMachine.tsx
+++ b/src/test-app/AppMachine.tsx
@@ -15,7 +15,6 @@ import { Link, RoutingEvent } from "../routing";
 import { TodosMachine } from "./TodosMachine";
 import { homeRoute, settingsRoute, history } from "./routes";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 type Context = {};
 type Events =
   | RoutingEvent<typeof homeRoute>

--- a/src/test-app/routes.ts
+++ b/src/test-app/routes.ts
@@ -4,17 +4,18 @@ import { buildCreateRoute } from "../routing";
 
 export const history = createMemoryHistory<any>();
 const createRoute = buildCreateRoute(history, "/");
-export const homeRoute = createRoute.dynamicRoute()({
-  matches: (url) => {
+export const homeRoute = createRoute.route()({
+  matcher(url, _query) {
     if (url === "/") {
-      return {};
+      return { matchLength: 1 };
     }
+
     return false;
   },
-  reverse: () => "/",
+  reverser: () => "/",
   event: "GO_HOME",
 });
-export const settingsRoute = createRoute.staticRoute()(
-  "/settings",
-  "GO_SETTINGS"
-);
+export const settingsRoute = createRoute.simpleRoute()({
+  url: "/settings",
+  event: "GO_SETTINGS",
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,9 +14,14 @@ export type OmitOptional<T> = {
     ? P
     : never]: T[P];
 };
-export type IsEmptyObject<Obj, ExcludeOptional extends boolean = false> = [
-  keyof (ExcludeOptional extends true ? OmitOptional<Obj> : Obj)
-] extends [never]
+export type IsEmptyObject<
+  Obj,
+  ExcludeOptional extends boolean = false
+> = undefined extends Obj
+  ? true
+  : [keyof (ExcludeOptional extends true ? OmitOptional<Obj> : Obj)] extends [
+      never
+    ]
   ? true
   : false;
 

--- a/xstate-tree.api.md
+++ b/xstate-tree.api.md
@@ -34,12 +34,13 @@ export type AnyRoute = {
     navigate: any;
     getEvent: any;
     event: string;
-    url?: string;
     basePath: string;
     history: XstateTreeHistory;
     parent?: AnyRoute;
     paramsSchema?: Z.ZodObject<any>;
     querySchema?: Z.ZodObject<any>;
+    matcher: (url: string, query: ParsedQuery<string> | undefined) => any;
+    reverser: any;
 };
 
 // @public (undocumented)
@@ -59,44 +60,39 @@ export function buildActions<TMachine extends AnyStateMachine, TActions, TSelect
 
 // @public
 export function buildCreateRoute(history: XstateTreeHistory, basePath: string): {
-    dynamicRoute: <TOpts extends Options<Z.ZodObject<any, "strip", Z.ZodTypeAny, {
+    simpleRoute<TBaseRoute extends AnyRoute>(baseRoute?: TBaseRoute | undefined): <TEvent extends string, TParamsSchema extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
         [x: string]: any;
     }, {
         [x: string]: any;
-    }>, Z.ZodObject<any, "strip", Z.ZodTypeAny, {
+    }> | undefined, TQuerySchema extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
         [x: string]: any;
     }, {
         [x: string]: any;
-    }>, any>>(opts?: TOpts | undefined) => <TEvent extends string, TParamsSchema = Params<TOpts>, TQuerySchema = Query<TOpts>, TMeta = Meta<TOpts>, TParams = TParamsSchema extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
-        [x: string]: any;
-    }, {
-        [x: string]: any;
-    }> ? Z.TypeOf<TParamsSchema> : undefined, TQuery = TQuerySchema extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
-        [x: string]: any;
-    }, {
-        [x: string]: any;
-    }> ? Z.TypeOf<TQuerySchema> : undefined, TFullMeta = TMeta extends undefined ? SharedMeta : TMeta & SharedMeta>({ event, matches, reverse, }: {
+    }> | undefined, TMeta extends Record<string, unknown>>({ url, paramsSchema, querySchema, ...args }: {
         event: TEvent;
-        matches: (url: string, query: ParsedQuery<string>) => false | RouteArguments<TParams, TQuery, TFullMeta>;
-        reverse: RouteArgumentFunctions<string, TParams, TQuery, TFullMeta, RouteArguments<TParams, TQuery, TFullMeta>>;
-    }) => Route<TParams, TQuery, TEvent, TFullMeta>;
-    staticRoute: <TBaseRoute extends AnyRoute | undefined = undefined, TBaseParams = RouteParams<TBaseRoute>, TBaseMeta = RouteMeta<TBaseRoute>>(baseRoute?: TBaseRoute | undefined) => <TOpts_1 extends Options<Z.ZodObject<any, "strip", Z.ZodTypeAny, {
+        url: string;
+        paramsSchema?: TParamsSchema | undefined;
+        querySchema?: TQuerySchema | undefined;
+        meta?: TMeta | undefined;
+    }) => Route<MergeRouteTypes<RouteParams<TBaseRoute>, ResolveZodType<TParamsSchema>>, ResolveZodType<TQuerySchema>, TEvent, MergeRouteTypes<RouteMeta<TBaseRoute>, TMeta> & SharedMeta>;
+    route<TBaseRoute_1 extends AnyRoute>(baseRoute?: TBaseRoute_1 | undefined): <TEvent_1 extends string, TParamsSchema_1 extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
         [x: string]: any;
     }, {
         [x: string]: any;
-    }>, Z.ZodObject<any, "strip", Z.ZodTypeAny, {
+    }> | undefined, TQuerySchema_1 extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
         [x: string]: any;
     }, {
         [x: string]: any;
-    }>, any>, TEvent_1 extends string, TParamsSchema_1 = Params<TOpts_1>, TQuerySchema_1 = Query<TOpts_1>, TMeta_1 = Meta<TOpts_1>, TParams_1 = TParamsSchema_1 extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
-        [x: string]: any;
-    }, {
-        [x: string]: any;
-    }> ? Z.TypeOf<TParamsSchema_1> : undefined, TQuery_1 = TQuerySchema_1 extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
-        [x: string]: any;
-    }, {
-        [x: string]: any;
-    }> ? Z.TypeOf<TQuerySchema_1> : undefined, TFullParams = TParams_1 extends undefined ? TBaseParams extends undefined ? undefined : TBaseParams : TParams_1 & (TBaseParams extends undefined ? {} : TBaseParams), TFullMeta_1 = TMeta_1 extends undefined ? TBaseMeta extends undefined ? SharedMeta : TBaseMeta & SharedMeta : TMeta_1 & (TBaseMeta extends undefined ? {} : TBaseMeta) & SharedMeta>(url: string, event: TEvent_1, opts?: TOpts_1 | undefined) => Route<TFullParams, TQuery_1, TEvent_1, TFullMeta_1>;
+    }> | undefined, TMeta_1 extends Record<string, unknown>>({ event, matcher, reverser, paramsSchema, querySchema, }: {
+        event: TEvent_1;
+        paramsSchema?: TParamsSchema_1 | undefined;
+        querySchema?: TQuerySchema_1 | undefined;
+        meta?: TMeta_1 | undefined;
+        matcher: (url: string, query: ParsedQuery<string> | undefined) => false | (RouteArguments<MergeRouteTypes<RouteParams<TBaseRoute_1>, ResolveZodType<TParamsSchema_1>>, ResolveZodType<TQuerySchema_1>, MergeRouteTypes<RouteMeta<TBaseRoute_1>, TMeta_1>> & {
+            matchLength: number;
+        });
+        reverser: RouteArgumentFunctions<string, MergeRouteTypes<RouteParams<TBaseRoute_1>, ResolveZodType<TParamsSchema_1>>, ResolveZodType<TQuerySchema_1>, MergeRouteTypes<RouteMeta<TBaseRoute_1>, TMeta_1>, RouteArguments<MergeRouteTypes<RouteParams<TBaseRoute_1>, ResolveZodType<TParamsSchema_1>>, ResolveZodType<TQuerySchema_1>, MergeRouteTypes<RouteMeta<TBaseRoute_1>, TMeta_1>>>;
+    }) => Route<MergeRouteTypes<RouteParams<TBaseRoute_1>, ResolveZodType<TParamsSchema_1>>, ResolveZodType<TQuerySchema_1>, TEvent_1, MergeRouteTypes<RouteMeta<TBaseRoute_1>, TMeta_1> & SharedMeta>;
 };
 
 // @public
@@ -159,7 +155,7 @@ export type GlobalEvents = {
 // Warning: (ae-forgotten-export) The symbol "States" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function lazy<TMachine extends AnyStateMachine>(factory: () => Promise<TMachine>, { Loader, withContext, }?: Options_2<TMachine["context"]>): StateMachine<Context, any, Events, States, any, any, any>;
+export function lazy<TMachine extends AnyStateMachine>(factory: () => Promise<TMachine>, { Loader, withContext, }?: Options<TMachine["context"]>): StateMachine<Context, any, Events, States, any, any, any>;
 
 // @public
 export function Link<TRoute extends AnyRoute>({ to, children, testId, ...rest }: LinkProps<TRoute>): JSX.Element;
@@ -209,13 +205,6 @@ export function multiSlot<T extends string>(name: T): MultiSlot<T>;
 export function onBroadcast(handler: (event: GlobalEvents) => void): () => void;
 
 // @public (undocumented)
-export type Options<TParamsSchema extends Z.ZodObject<any>, TQuerySchema extends Z.ZodObject<any>, TMetaSchema> = {
-    params?: TParamsSchema;
-    query?: TQuerySchema;
-    meta?: TMetaSchema;
-};
-
-// @public (undocumented)
 export type OutputFromSelector<T> = T extends Selectors<any, any, infer O, any> ? O : never;
 
 // @public
@@ -240,14 +229,17 @@ export type Route<TParams, TQuery, TEvent, TMeta> = {
     matches: (url: string, search: string) => ({
         type: TEvent;
         originalUrl: string;
-    } & RouteArguments<TParams, TQuery, TMeta>) | undefined;
+    } & RouteArguments<TParams, TQuery, TMeta>) | false;
     reverse: RouteArgumentFunctions<string, TParams, TQuery, undefined>;
     navigate: RouteArgumentFunctions<void, TParams, TQuery, TMeta>;
     getEvent: RouteArgumentFunctions<{
         type: TEvent;
     } & RouteArguments<TParams, TQuery, TMeta>, TParams, TQuery, TMeta>;
+    matcher: (url: string, query: ParsedQuery<string> | undefined) => (RouteArguments<TParams, TQuery, TMeta> & {
+        matchLength: number;
+    }) | false;
+    reverser: RouteArgumentFunctions<string, TParams, TQuery, TMeta>;
     event: TEvent;
-    url?: string;
     history: XstateTreeHistory;
     basePath: string;
     parent?: AnyRoute;
@@ -376,6 +368,8 @@ export type XstateTreeMachineStateSchema<TMachine extends AnyStateMachine, TSele
 
 // Warnings were encountered during analysis:
 //
+// src/routing/createRoute/createRoute.ts:252:78 - (ae-forgotten-export) The symbol "MergeRouteTypes" needs to be exported by the entry point index.d.ts
+// src/routing/createRoute/createRoute.ts:252:78 - (ae-forgotten-export) The symbol "ResolveZodType" needs to be exported by the entry point index.d.ts
 // src/types.ts:22:3 - (ae-incompatible-release-tags) The symbol "view" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal
 
 // (No @packageDocumentation comment for this package)


### PR DESCRIPTION
Overhauls the route creation system to enable composing dynamic routes together. With the previous system only static routes (a fixed url) could be composed together. If you wanted a dynamic URL you were limited to not creating sub routes from it.

Now everything is an equivalent to a dynamic route and the static routes are built ontop of them.

The `any` type massacre in the create route functions has only gotten worse, sadly.