### PR TITLE
feat(routing): async redirects 

### DIFF
--- a/src/tests/asyncRouteRedirects.spec.tsx
+++ b/src/tests/asyncRouteRedirects.spec.tsx
@@ -1,0 +1,108 @@
+import { render } from "@testing-library/react";
+import { assign } from "@xstate/immer";
+import { createMemoryHistory } from "history";
+import React from "react";
+import { createMachine } from "xstate";
+import { z } from "zod";
+
+import {
+  buildRootComponent,
+  buildActions,
+  buildCreateRoute,
+  buildSelectors,
+  buildView,
+  buildXStateTreeMachine,
+  XstateTreeHistory,
+} from "../";
+import { delay } from "../utils";
+
+describe("async route redirects", () => {
+  const hist: XstateTreeHistory = createMemoryHistory();
+  const createRoute = buildCreateRoute(hist, "/");
+
+  const parentRoute = createRoute.simpleRoute()({
+    url: "/:notFoo/",
+    event: "GO_TO_PARENT",
+    paramsSchema: z.object({ notFoo: z.string() }),
+    redirect: async ({ params }) => {
+      await delay(100);
+
+      if (params.notFoo === "foo") {
+        return { params: { notFoo: "notFoo" } };
+      }
+    },
+  });
+  const redirectRoute = createRoute.simpleRoute(parentRoute)({
+    url: "/foo/:bar/",
+    event: "GO_TO_REDIRECT",
+    paramsSchema: z.object({ bar: z.string() }),
+    redirect: async ({ params }) => {
+      if (params.bar === "redirect") {
+        return {
+          params: {
+            bar: "redirected",
+          },
+        };
+      }
+    },
+  });
+  const childRoute = createRoute.simpleRoute(redirectRoute)({
+    url: "/child/",
+    event: "GO_TO_CHILD",
+  });
+
+  const machine = createMachine<any, any>({
+    context: {},
+    initial: "idle",
+    on: {
+      GO_TO_REDIRECT: {
+        actions: assign((ctx, e) => {
+          ctx.bar = e.params.bar;
+        }),
+      },
+    },
+    states: {
+      idle: {},
+    },
+  });
+  const selectors = buildSelectors(machine, (ctx) => ctx);
+  const actions = buildActions(machine, selectors, () => ({}));
+  const view = buildView(machine, selectors, actions, [], ({ selectors }) => (
+    <p>{selectors.bar}</p>
+  ));
+
+  const Root = buildRootComponent(
+    buildXStateTreeMachine(machine, { actions, selectors, view, slots: [] }),
+    {
+      basePath: "/",
+      history: hist,
+      routes: [parentRoute, redirectRoute, childRoute],
+    }
+  );
+
+  it("handles a top/middle/bottom route hierarchy where top and middle perform a redirect", async () => {
+    const { queryByText } = render(<Root />);
+
+    childRoute.navigate({ params: { bar: "redirect", notFoo: "foo" } });
+
+    await delay(140);
+    expect(queryByText("redirected")).toBeDefined();
+    expect(hist.location.pathname).toBe("/notFoo/foo/redirected/child/");
+  });
+
+  it("respects the abort controller and aborts the redirect on route navigation", async () => {
+    const { queryByText } = render(<Root />);
+
+    childRoute.navigate({ params: { bar: "redirect", notFoo: "foo" } });
+    await delay();
+    childRoute.navigate({
+      params: { bar: "icancelledtheredirect", notFoo: "foo" },
+    });
+
+    await delay(140);
+    expect(queryByText("icancelledtheredirect")).toBeDefined();
+    expect(hist.location.pathname).toBe(
+      "/notFoo/foo/icancelledtheredirect/child/"
+    );
+  });
+});

--- a/src/xstateTree.tsx
+++ b/src/xstateTree.tsx
@@ -29,7 +29,7 @@ import { GetSlotNames, Slot } from "./slots";
 import { GlobalEvents, AnyXstateTreeMachine, XstateTreeHistory } from "./types";
 import { useConstant } from "./useConstant";
 import { useService } from "./useService";
-import { isLikelyPageLoad } from "./utils";
+import { assertIsDefined, isLikelyPageLoad } from "./utils";
 
 export const emitter = new TinyEmitter();
 
@@ -303,6 +303,9 @@ export function buildRootComponent(
 
   const RootComponent = function XstateTreeRootComponent() {
     const [_, __, interpreter] = useMachine(machine, { devTools: true });
+    const [activeRoute, setActiveRoute] = useState<AnyRoute | undefined>(
+      undefined
+    );
     const activeRouteEventsRef = useRef<RoutingEvent<any>[]>([]);
     const [forceRenderValue, forceRender] = useState(false);
     const setActiveRouteEvents = (events: RoutingEvent<any>[]) => {
@@ -322,6 +325,81 @@ export function buildRootComponent(
     }, [interpreter]);
 
     useEffect(() => {
+      if (activeRoute === undefined) {
+        return;
+      }
+
+      const controller = new AbortController();
+      const routes: AnyRoute[] = [activeRoute];
+
+      let route: AnyRoute = activeRoute;
+      while (route.parent) {
+        routes.unshift(route.parent);
+        route = route.parent;
+      }
+
+      const routeEventPairs: [AnyRoute, RoutingEvent<any>][] = [];
+      const activeRoutesEvent = activeRouteEventsRef.current.find(
+        (e) => e.type === activeRoute.event
+      );
+      assertIsDefined(activeRoutesEvent);
+
+      for (let i = 0; i < routes.length; i++) {
+        const route = routes[i];
+        const routeEvent = activeRouteEventsRef.current[i];
+        routeEventPairs.push([route, routeEvent]);
+      }
+
+      const routePairsWithRedirects = routeEventPairs.filter(([route]) => {
+        return route.redirect !== undefined;
+      });
+
+      const redirectPromises = routePairsWithRedirects.map(([route, event]) => {
+        assertIsDefined(route.redirect);
+
+        return route.redirect({
+          signal: controller.signal,
+          query: event.query,
+          params: event.params,
+          meta: event.meta,
+        });
+      });
+
+      void Promise.all(redirectPromises).then((redirects) => {
+        const didAnyRedirect = redirects.some((x) => x !== undefined);
+
+        if (!didAnyRedirect || controller.signal.aborted) {
+          return;
+        }
+
+        const routeArguments = redirects.reduce(
+          (args, redirect) => {
+            if (redirect) {
+              args.query = { ...args.query, ...redirect.query };
+              args.params = { ...args.params, ...redirect.params };
+              args.meta = { ...args.meta, ...redirect.meta };
+            }
+
+            return args;
+          },
+          {
+            // since the redirect results are partials, need to merge them with the original event
+            // params/query to ensure that all params/query are present
+            query: { ...(activeRoutesEvent.query ?? {}) },
+            params: { ...(activeRoutesEvent.params ?? {}) },
+            meta: { ...(activeRoutesEvent.meta ?? {}) },
+          }
+        );
+
+        activeRoute.navigate(routeArguments);
+      });
+
+      return () => {
+        controller.abort();
+      };
+    }, [activeRoute]);
+
+    useEffect(() => {
       if (routing) {
         const {
           getPathName = () => window.location.pathname,
@@ -329,14 +407,18 @@ export function buildRootComponent(
         } = routing;
 
         const queryString = getQueryString();
-        handleLocationChange(
+        const result = handleLocationChange(
           routing.routes,
           routing.basePath,
           getPathName(),
           getQueryString(),
-          setActiveRouteEvents,
           { onloadEvent: isLikelyPageLoad() } as SharedMeta
         );
+
+        if (result) {
+          setActiveRouteEvents(result.events);
+          setActiveRoute({ ...result.matchedRoute });
+        }
 
         // Hack to ensure the initial location doesn't have undefined state
         // It's not supposed to, but it does for some reason
@@ -348,14 +430,18 @@ export function buildRootComponent(
     useEffect(() => {
       if (routing) {
         const unsub = routing.history.listen((location) => {
-          handleLocationChange(
+          const result = handleLocationChange(
             routing.routes,
             routing.basePath,
             location.pathname,
             location.search,
-            setActiveRouteEvents,
             location.state?.meta
           );
+
+          if (result) {
+            setActiveRouteEvents(result.events);
+            setActiveRoute({ ...result.matchedRoute });
+          }
         });
 
         return () => {


### PR DESCRIPTION
Adds support for defining async redirect functions on routes to enable redirecting after the URL has matched based on any arbitrary logic you require