### PR TITLE
feat(builders): builders 2.0 

### DIFF
--- a/examples/todomvc/App.tsx
+++ b/examples/todomvc/App.tsx
@@ -1,12 +1,9 @@
 import {
   broadcast,
-  buildActions,
-  buildSelectors,
-  buildView,
-  buildXStateTreeMachine,
   multiSlot,
   Link,
   RoutingEvent,
+  createXStateTreeMachine,
 } from "@koordinates/xstate-tree";
 import { assign } from "@xstate/immer";
 import React from "react";
@@ -29,7 +26,6 @@ type Events =
   | RoutingEvent<typeof completedTodos>;
 
 const TodosSlot = multiSlot("Todos");
-const slots = [TodosSlot];
 const machine =
   /** @xstate-layout N4IgpgJg5mDOIC5QBcD2FUFoCGAHXAdAMaoB2EArkWgE4DEiouqsAlsq2YyAB6ICMAFgBMBAJwTBANgkBWAOwAOWQGYpwgDQgAngMEEp-RYNn8FABmHmxMlQF87WtBhz46AZQCaAOQDCAfQAVAHkAEWD3bmY2Di4kXkRMeSkCEWTzRUUbYUV5c1ktXQRMflKCMyUxQXk1Y2FShyd0LDxcDwAJYIB1fwBBX0CASQA1AFEgsIiolnZOUm4+BBUagitzFWFZasVzczMpQsThFeVFFV35fjzLQUaQZxa3d06e3oAZN4nwyPjo2bjQIt+FJFKsxNYxLIbLJNoIxIpDsUVFDUsJBGcVGIrPxjrdHPdmq42s9uv5fMEALIABTeo0Co1CXymvxmsXm8UWJWsBB2ljUVThe2EBx0iWRYlR6JUmOxuIc+NI6Dg3AeROIZEo1FQNGmMTmC0SslBVRqIJE-HywsEgkRVwIlWqan40tM-DuqtaBEVgWa8BZeoBCQQV1EUhUFSyjrNNtFwZs4kjpysKkUwjU7sJnoAFthYD6MH6mKz9RzDeYCDCwxGTfzbfH4VUk+tU+n8R78Lr-uzAYkLeW0lIMll1Ll8ojMGiUhGzkIU2JWw4gA */
   createMachine(
@@ -111,48 +107,50 @@ const machine =
     }
   );
 
-const selectors = buildSelectors(machine, (ctx) => ({
-  get count() {
-    const completedCount = ctx.todos.filter((t) => t.completed).length;
-    const activeCount = ctx.todos.length - completedCount;
+export const TodoApp = createXStateTreeMachine(machine, {
+  selectors({ ctx, inState }) {
+    return {
+      get count() {
+        const completedCount = ctx.todos.filter((t) => t.completed).length;
+        const activeCount = ctx.todos.length - completedCount;
 
-    return ctx.filter === "completed" ? completedCount : activeCount;
-  },
-  get countText() {
-    const count = this.count;
-    const plural = count === 1 ? "" : "s";
+        return ctx.filter === "completed" ? completedCount : activeCount;
+      },
+      get countText() {
+        const count = this.count;
+        const plural = count === 1 ? "" : "s";
 
-    return `item${plural} ${ctx.filter === "completed" ? "completed" : "left"}`;
+        return `item${plural} ${
+          ctx.filter === "completed" ? "completed" : "left"
+        }`;
+      },
+      allCompleted: ctx.todos.every((t) => t.completed),
+      haveCompleted: ctx.todos.some((t) => t.completed),
+      allTodosClass: ctx.filter === "all" ? "selected" : undefined,
+      activeTodosClass: ctx.filter === "active" ? "selected" : undefined,
+      completedTodosClass: ctx.filter === "completed" ? "selected" : undefined,
+      hasTodos: inState("hasTodos"),
+    };
   },
-  allCompleted: ctx.todos.every((t) => t.completed),
-  haveCompleted: ctx.todos.some((t) => t.completed),
-  allTodosClass: ctx.filter === "all" ? "selected" : undefined,
-  activeTodosClass: ctx.filter === "active" ? "selected" : undefined,
-  completedTodosClass: ctx.filter === "completed" ? "selected" : undefined,
-}));
+  actions() {
+    return {
+      addTodo(title: string) {
+        const trimmed = title.trim();
 
-const actions = buildActions(machine, selectors, () => ({
-  addTodo(title: string) {
-    const trimmed = title.trim();
-
-    if (trimmed.length > 0) {
-      broadcast({ type: "TODO_CREATED", text: trimmed });
-    }
+        if (trimmed.length > 0) {
+          broadcast({ type: "TODO_CREATED", text: trimmed });
+        }
+      },
+      completeAll(completed: boolean) {
+        broadcast({ type: "TODO_ALL_COMPLETED", completed });
+      },
+      clearCompleted() {
+        broadcast({ type: "TODO_COMPLETED_CLEARED" });
+      },
+    };
   },
-  completeAll(completed: boolean) {
-    broadcast({ type: "TODO_ALL_COMPLETED", completed });
-  },
-  clearCompleted() {
-    broadcast({ type: "TODO_COMPLETED_CLEARED" });
-  },
-}));
-
-const view = buildView(
-  machine,
-  selectors,
-  actions,
-  slots,
-  ({ inState, actions, selectors, slots }) => {
+  slots: [TodosSlot],
+  view({ actions, selectors, slots }) {
     return (
       <>
         <section className="todoapp">
@@ -170,7 +168,7 @@ const view = buildView(
             />
           </header>
 
-          {inState("hasTodos") && (
+          {selectors.hasTodos && (
             <>
               <section className="main">
                 <input
@@ -234,12 +232,5 @@ const view = buildView(
         </footer>
       </>
     );
-  }
-);
-
-export const TodoApp = buildXStateTreeMachine(machine, {
-  view,
-  actions,
-  selectors,
-  slots,
+  },
 });

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -13,17 +13,17 @@ import { Slot } from "./slots";
 import {
   AnyActions,
   AnySelector,
+  CanHandleEvent,
   MatchesFrom,
   OutputFromSelector,
-  Selectors,
+  V1Selectors as LegacySelectors,
+  V2BuilderMeta,
   ViewProps,
-  XStateTreeMachineMeta,
-  XstateTreeMachineStateSchema,
+  XStateTreeMachineMetaV1,
+  XstateTreeMachineStateSchemaV1,
+  XstateTreeMachineStateSchemaV2,
 } from "./types";
 
-type CanHandleEvent<TMachine extends AnyStateMachine> = (
-  e: EventFrom<TMachine>
-) => boolean;
 /**
  * @public
  *
@@ -39,6 +39,7 @@ type CanHandleEvent<TMachine extends AnyStateMachine> = (
  * @param machine - The machine to create the selectors for
  * @param selectors - The selector function
  * @returns The selectors - ready to be passed to {@link buildActions}
+ * @deprecated use {@link createXStateTreeMachine} instead
  */
 export function buildSelectors<
   TMachine extends AnyStateMachine,
@@ -52,7 +53,12 @@ export function buildSelectors<
     inState: MatchesFrom<TMachine>,
     __currentState: never
   ) => TSelectors
-): Selectors<TContext, EventFrom<TMachine>, TSelectors, MatchesFrom<TMachine>> {
+): LegacySelectors<
+  TContext,
+  EventFrom<TMachine>,
+  TSelectors,
+  MatchesFrom<TMachine>
+> {
   let lastState: never | undefined = undefined;
   let lastCachedResult: TSelectors | undefined = undefined;
   let lastCtxRef: TContext | undefined = undefined;
@@ -98,6 +104,7 @@ export function buildSelectors<
  * @param selectors - The selectors function
  * @param actions - The action function
  * @returns The actions function - ready to be passed to {@link buildView}
+ * @deprecated use {@link createXStateTreeMachine} instead
  * */
 export function buildActions<
   TMachine extends AnyStateMachine,
@@ -129,6 +136,7 @@ export function buildActions<
  * @param slots - The array of slots that can be rendered by the view
  * @param view - The view function
  * @returns The React view
+ * @deprecated use {@link createXStateTreeMachine} instead
  */
 export function buildView<
   TMachine extends AnyStateMachine,
@@ -165,6 +173,7 @@ export function buildView<
  * @param machine - The machine to staple the selectors/actions/slots/view to
  * @param metadata - The xstate-tree metadata to staple to the machine
  * @returns The xstate-tree machine, ready to be invoked by other xstate-machines or used with `buildRootComponent`
+ * @deprecated use {@link createXStateTreeMachine} instead
  */
 export function buildXStateTreeMachine<
   TMachine extends AnyStateMachine,
@@ -172,10 +181,10 @@ export function buildXStateTreeMachine<
   TActions extends AnyActions
 >(
   machine: TMachine,
-  meta: XStateTreeMachineMeta<TMachine, TSelectors, TActions>
+  meta: XStateTreeMachineMetaV1<TMachine, TSelectors, TActions>
 ): StateMachine<
   ContextFrom<TMachine>,
-  XstateTreeMachineStateSchema<TMachine, TSelectors, TActions>,
+  XstateTreeMachineStateSchemaV1<TMachine, TSelectors, TActions>,
   EventFrom<TMachine>,
   any,
   any,
@@ -184,8 +193,71 @@ export function buildXStateTreeMachine<
 > {
   const copiedMeta = { ...meta };
   copiedMeta.xstateTreeMachine = true;
-  machine.config.meta = { ...machine.config.meta, ...copiedMeta };
-  machine.meta = { ...machine.meta, ...copiedMeta };
+  machine.config.meta = {
+    ...machine.config.meta,
+    ...copiedMeta,
+    builderVersion: 1,
+  };
+  machine.meta = { ...machine.meta, ...copiedMeta, builderVersion: 1 };
+
+  return machine;
+}
+
+/**
+ * @public
+ * Creates an xstate-tree machine from an xstate-machine
+ *
+ * Accepts an options object defining the selectors/actions/slots and view for the xstate-tree machine
+ *
+ * Selectors/slots/actions can be omitted from the options object and will default to
+ * - actions: an empty object
+ * - selectors: the context of the machine
+ * - slots: an empty array
+ *
+ * @param machine - The xstate machine to create the xstate-tree machine from
+ * @param options - the xstate-tree options
+ */
+export function createXStateTreeMachine<
+  TMachine extends AnyStateMachine,
+  TSelectorsOutput = ContextFrom<TMachine>,
+  TActionsOutput = Record<never, string>,
+  TSlots extends readonly Slot[] = []
+>(
+  machine: TMachine,
+  options: V2BuilderMeta<TMachine, TSelectorsOutput, TActionsOutput, TSlots>
+): StateMachine<
+  ContextFrom<TMachine>,
+  XstateTreeMachineStateSchemaV2<
+    TMachine,
+    TSelectorsOutput,
+    TActionsOutput,
+    TSlots
+  >,
+  EventFrom<TMachine>,
+  any,
+  any,
+  any,
+  any
+> {
+  const selectors = options.selectors ?? (({ ctx }) => ctx);
+  const actions = options.actions ?? (() => ({}));
+
+  const xstateTreeMeta = {
+    selectors,
+    actions,
+    view: options.view,
+    slots: options.slots ?? [],
+  };
+  machine.meta = {
+    ...machine.meta,
+    ...xstateTreeMeta,
+    builderVersion: 2,
+  };
+  machine.config.meta = {
+    ...machine.config.meta,
+    ...xstateTreeMeta,
+    builderVersion: 2,
+  };
 
   return machine;
 }

--- a/src/test-app/AppMachine.tsx
+++ b/src/test-app/AppMachine.tsx
@@ -2,13 +2,10 @@ import React from "react";
 import { createMachine } from "xstate";
 
 import {
-  buildView,
-  buildXStateTreeMachine,
   buildRootComponent,
   singleSlot,
-  buildActions,
   lazy,
-  buildSelectors,
+  createXStateTreeMachine,
 } from "../";
 import { Link, RoutingEvent } from "../routing";
 
@@ -64,18 +61,18 @@ const AppMachine =
     }
   );
 
-const selectors = buildSelectors(AppMachine, (ctx) => ctx);
-const actions = buildActions(AppMachine, selectors, () => ({}));
-
-const AppView = buildView(
-  AppMachine,
-  selectors,
-  actions,
+export const BuiltAppMachine = createXStateTreeMachine(AppMachine, {
   slots,
-  ({ slots, inState }) => {
+  selectors({ inState }) {
+    return {
+      showingTodos: inState("todos"),
+      showingOtherScreen: inState("otherScreen"),
+    };
+  },
+  view({ slots, selectors }) {
     return (
       <>
-        {inState("todos") && (
+        {selectors.showingTodos && (
           <>
             <p data-testid="header">On home</p>
             <Link to={settingsRoute} testId="swap-to-other-machine">
@@ -83,7 +80,7 @@ const AppView = buildView(
             </Link>
           </>
         )}
-        {inState("otherScreen") && (
+        {selectors.showingOtherScreen && (
           <>
             <p data-testid="header">On settings</p>
             <Link to={homeRoute} testId="swap-to-other-machine">
@@ -94,17 +91,10 @@ const AppView = buildView(
         <slots.ScreenGoesHere />
       </>
     );
-  }
-);
-
-export const BuiltAppMachine = buildXStateTreeMachine(AppMachine, {
-  actions,
-  selectors,
-  slots,
-  view: AppView,
+  },
 });
 
-export const App = buildRootComponent(BuiltAppMachine, {
+export const App = buildRootComponent(BuiltAppMachine as any, {
   history,
   basePath: "",
   routes: [homeRoute, settingsRoute],

--- a/src/test-app/OtherMachine.tsx
+++ b/src/test-app/OtherMachine.tsx
@@ -1,13 +1,7 @@
 import React from "react";
 import { createMachine } from "xstate";
 
-import {
-  buildActions,
-  buildSelectors,
-  buildView,
-  buildXStateTreeMachine,
-  PickEvent,
-} from "../";
+import { createXStateTreeMachine, PickEvent } from "../";
 import { RoutingEvent } from "../routing";
 
 import { settingsRoute } from "./routes";
@@ -47,24 +41,20 @@ const machine = createMachine<unknown, Events, States>({
   },
 });
 
-const selectors = buildSelectors(machine, (_ctx, canHandleEvent) => ({
-  canDoTheThing: canHandleEvent({ type: "DO_THE_THING" }),
-}));
-const actions = buildActions(machine, selectors, () => ({}));
-const view = buildView(machine, selectors, actions, [], ({ selectors }) => {
-  return (
-    <>
-      <p data-testid="can-do-the-thing">
-        {selectors.canDoTheThing ? "true" : "false"}
-      </p>
-      <p data-testid="other-text">Other</p>
-    </>
-  );
-});
-
-export const OtherMachine = buildXStateTreeMachine(machine, {
-  view,
-  slots: [],
-  actions,
-  selectors,
+export const OtherMachine = createXStateTreeMachine(machine, {
+  selectors({ canHandleEvent }) {
+    return {
+      canDoTheThing: canHandleEvent({ type: "DO_THE_THING" }),
+    };
+  },
+  view({ selectors }) {
+    return (
+      <>
+        <p data-testid="can-do-the-thing">
+          {selectors.canDoTheThing ? "true" : "false"}
+        </p>
+        <p data-testid="other-text">Other</p>
+      </>
+    );
+  },
 });

--- a/src/test-app/TodosMachine.tsx
+++ b/src/test-app/TodosMachine.tsx
@@ -8,14 +8,7 @@ import {
   ActorRefFrom,
 } from "xstate";
 
-import {
-  broadcast,
-  buildSelectors,
-  buildActions,
-  buildView,
-  multiSlot,
-  buildXStateTreeMachine,
-} from "../";
+import { broadcast, multiSlot, createXStateTreeMachine } from "../";
 import { assert } from "../utils";
 
 import { TodoMachine } from "./TodoMachine";
@@ -171,22 +164,24 @@ const TodosMachine = createMachine<Context, Events, State>(
   }
 );
 
-const TodosSelectors = buildSelectors(TodosMachine, (ctx) => {
-  return {
-    todoInput: ctx.newTodo,
-    allCompleted: ctx.todos.every(
-      (todoActor) => todoActor.state.context.completed
-    ),
-    uncompletedCount: ctx.todos.filter(
-      (todoActor) => !todoActor.state.context.completed
-    ).length,
-  };
-});
-
-const TodosActions = buildActions(
-  TodosMachine,
-  TodosSelectors,
-  (send, selectors) => {
+const BuiltTodosMachine = createXStateTreeMachine(TodosMachine, {
+  selectors({ ctx, inState }) {
+    return {
+      todoInput: ctx.newTodo,
+      allCompleted: ctx.todos.every(
+        (todoActor) => todoActor.state.context.completed
+      ),
+      uncompletedCount: ctx.todos.filter(
+        (todoActor) => !todoActor.state.context.completed
+      ).length,
+      loading: inState("loadingTodos"),
+      haveTodos: inState("haveTodos"),
+      onActive: inState("haveTodos.active"),
+      onCompleted: inState("haveTodos.completed"),
+      onAll: inState("haveTodos.all"),
+    };
+  },
+  actions({ send, selectors }) {
     return {
       todoInputChanged(newVal: string) {
         send({ type: "TODO_INPUT_CHANGED", val: newVal });
@@ -213,16 +208,9 @@ const TodosActions = buildActions(
         send({ type: "COMPLETED_SELECTED" });
       },
     };
-  }
-);
-
-const TodosView = buildView(
-  TodosMachine,
-  TodosSelectors,
-  TodosActions,
-  slots,
-  ({ slots, actions, selectors, inState }) => {
-    if (inState("loadingTodos")) {
+  },
+  view({ slots, actions, selectors }) {
+    if (selectors.loading) {
       return <p>Loading</p>;
     }
 
@@ -240,7 +228,7 @@ const TodosView = buildView(
             data-testid="todo-input"
           />
         </header>
-        {inState("haveTodos") && (
+        {selectors.haveTodos && (
           <>
             <section className="main">
               <input
@@ -266,7 +254,7 @@ const TodosView = buildView(
               <ul className="filters">
                 <li>
                   <a
-                    className={cx({ selected: inState("haveTodos.all") })}
+                    className={cx({ selected: selectors.onAll })}
                     href="#/"
                     onClick={actions.viewAllTodos}
                     data-testid="view-all"
@@ -276,7 +264,7 @@ const TodosView = buildView(
                 </li>
                 <li>
                   <a
-                    className={cx({ selected: inState("haveTodos.active") })}
+                    className={cx({ selected: selectors.onActive })}
                     href="#/active"
                     onClick={actions.viewActiveTodos}
                     data-testid="view-active"
@@ -286,7 +274,7 @@ const TodosView = buildView(
                 </li>
                 <li>
                   <a
-                    className={cx({ selected: inState("haveTodos.completed") })}
+                    className={cx({ selected: selectors.onCompleted })}
                     href="#/completed"
                     onClick={actions.viewCompletedTodos}
                   >
@@ -305,13 +293,7 @@ const TodosView = buildView(
         )}
       </>
     );
-  }
-);
-
-const BuiltTodosMachine = buildXStateTreeMachine(TodosMachine, {
-  view: TodosView,
-  selectors: TodosSelectors,
-  actions: TodosActions,
+  },
   slots,
 });
 

--- a/src/test-app/tests/itWorksWithoutRouting.integration.tsx
+++ b/src/test-app/tests/itWorksWithoutRouting.integration.tsx
@@ -4,11 +4,8 @@ import { createMachine } from "xstate";
 
 import {
   buildRootComponent,
-  buildSelectors,
-  buildActions,
-  buildView,
-  buildXStateTreeMachine,
   singleSlot,
+  createXStateTreeMachine,
 } from "../../";
 
 const childMachine = createMachine({
@@ -18,28 +15,12 @@ const childMachine = createMachine({
   },
 });
 
-const childSelectors = buildSelectors(childMachine, (ctx) => ctx);
-const childActions = buildActions(childMachine, childSelectors, () => ({}));
-const childView = buildView(
-  childMachine,
-  childSelectors,
-  childActions,
-  [],
-  () => {
-    return <p data-testid="child">child</p>;
-  }
-);
-
-const child = buildXStateTreeMachine(childMachine, {
-  actions: childActions,
-  selectors: childSelectors,
-  slots: [],
-  view: childView,
+const child = createXStateTreeMachine(childMachine, {
+  view: () => <p data-testid="child">child</p>,
 });
 
 const childSlot = singleSlot("Child");
-const slots = [childSlot];
-const rootMachine = createMachine({
+const rootMachine = createMachine<any, any, any>({
   initial: "idle",
   invoke: {
     src: () => child,
@@ -49,22 +30,17 @@ const rootMachine = createMachine({
     idle: {},
   },
 });
-const selectors = buildSelectors(rootMachine, (ctx) => ctx);
-const actions = buildActions(rootMachine, selectors, () => ({}));
-const view = buildView(rootMachine, selectors, actions, slots, ({ slots }) => {
-  return (
-    <>
-      <p data-testid="root">root</p>
-      <slots.Child />
-    </>
-  );
-});
 
-const root = buildXStateTreeMachine(rootMachine, {
-  selectors,
-  actions,
-  slots,
-  view,
+const root = createXStateTreeMachine(rootMachine, {
+  slots: [childSlot],
+  view({ slots }) {
+    return (
+      <>
+        <p data-testid="root">root</p>
+        <slots.Child />
+      </>
+    );
+  },
 });
 
 const RootView = buildRootComponent(root);

--- a/src/testingUtilities.tsx
+++ b/src/testingUtilities.tsx
@@ -12,7 +12,7 @@ import {
 
 import { buildXStateTreeMachine } from "./builders";
 import {
-  XstateTreeMachineStateSchema,
+  XstateTreeMachineStateSchemaV1,
   GlobalEvents,
   ViewProps,
   AnySelector,
@@ -129,7 +129,7 @@ export function buildTestRootComponent<
 >(
   machine: StateMachine<
     TContext,
-    XstateTreeMachineStateSchema<TMachine, TSelectors, TActions>,
+    XstateTreeMachineStateSchemaV1<TMachine, TSelectors, TActions>,
     EventFrom<TMachine>
   >,
   logger: typeof console.log

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,9 @@ export type ViewProps<
   slots: Record<GetSlotNames<TSlots>, React.ComponentType>;
   actions: TActions;
   selectors: TSelectors;
+  /**
+   * @deprecated see https://github.com/koordinates/xstate-tree/issues/33 use `inState` in the selector function instead
+   */
   inState: TMatches;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,9 @@ import React from "react";
 import type {
   AnyFunction,
   AnyStateMachine,
+  ContextFrom,
+  EventFrom,
+  InterpreterFrom,
   StateFrom,
   StateMachine,
 } from "xstate";
@@ -12,7 +15,7 @@ import { Slot, GetSlotNames } from "./slots";
 /**
  * @public
  */
-export type XStateTreeMachineMeta<
+export type XStateTreeMachineMetaV1<
   TMachine extends AnyStateMachine,
   TSelectors,
   TActions extends AnyActions,
@@ -35,12 +38,14 @@ export type XStateTreeMachineMeta<
 /**
  * @public
  */
-export type XstateTreeMachineStateSchema<
+export type XstateTreeMachineStateSchemaV1<
   TMachine extends AnyStateMachine,
   TSelectors extends AnySelector,
   TActions extends AnyActions
 > = {
-  meta: XStateTreeMachineMeta<TMachine, TSelectors, TActions>;
+  meta: XStateTreeMachineMetaV1<TMachine, TSelectors, TActions> & {
+    builderVersion: 1;
+  };
 };
 
 /**
@@ -108,7 +113,7 @@ export type XstateTreeHistory<T = unknown> = History<{
 /**
  * @public
  */
-export type Selectors<TContext, TEvent, TSelectors, TMatches> = (
+export type V1Selectors<TContext, TEvent, TSelectors, TMatches> = (
   ctx: TContext,
   canHandleEvent: (e: TEvent) => boolean,
   inState: TMatches,
@@ -123,14 +128,19 @@ export type MatchesFrom<T extends AnyStateMachine> = StateFrom<T>["matches"];
 /**
  * @public
  */
-export type OutputFromSelector<T> = T extends Selectors<any, any, infer O, any>
+export type OutputFromSelector<T> = T extends V1Selectors<
+  any,
+  any,
+  infer O,
+  any
+>
   ? O
   : never;
 
 /**
  * @public
  */
-export type AnySelector = Selectors<any, any, any, any>;
+export type AnySelector = V1Selectors<any, any, any, any>;
 
 /**
  * @public
@@ -142,6 +152,79 @@ export type AnyActions = (send: any, selectors: any) => any;
  */
 export type AnyXstateTreeMachine = StateMachine<
   any,
-  XstateTreeMachineStateSchema<AnyStateMachine, any, any>,
+  | XstateTreeMachineStateSchemaV1<AnyStateMachine, AnySelector, AnyActions>
+  | XstateTreeMachineStateSchemaV2<AnyStateMachine, any, any>,
   any
 >;
+
+/**
+ * @internal
+ */
+export type CanHandleEvent<TMachine extends AnyStateMachine> = (
+  e: EventFrom<TMachine>
+) => boolean;
+
+/**
+ * @public
+ */
+export type Selectors<TMachine extends AnyStateMachine, TOut> = (args: {
+  ctx: ContextFrom<TMachine>;
+  canHandleEvent: CanHandleEvent<TMachine>;
+  inState: MatchesFrom<TMachine>;
+}) => TOut;
+
+/**
+ * @public
+ */
+export type Actions<
+  TMachine extends AnyStateMachine,
+  TSelectorsOutput,
+  TOut
+> = (args: {
+  send: InterpreterFrom<TMachine>["send"];
+  selectors: TSelectorsOutput;
+}) => TOut;
+
+/**
+ * @public
+ */
+export type View<
+  TActionsOutput,
+  TSelectorsOutput,
+  TSlots extends readonly Slot[]
+> = React.ComponentType<{
+  slots: Record<GetSlotNames<TSlots>, React.ComponentType>;
+  actions: TActionsOutput;
+  selectors: TSelectorsOutput;
+}>;
+
+/**
+ * @public
+ */
+export type V2BuilderMeta<
+  TMachine extends AnyStateMachine,
+  TSelectorsOutput = ContextFrom<TMachine>,
+  TActionsOutput = Record<never, string>,
+  TSlots extends readonly Slot[] = Slot[]
+> = {
+  selectors?: Selectors<TMachine, TSelectorsOutput>;
+  actions?: Actions<TMachine, TSelectorsOutput, TActionsOutput>;
+  slots?: TSlots;
+  view: View<TActionsOutput, TSelectorsOutput, TSlots>;
+};
+
+/**
+ * @public
+ */
+export type XstateTreeMachineStateSchemaV2<
+  TMachine extends AnyStateMachine,
+  TSelectorsOutput = ContextFrom<TMachine>,
+  TActionsOutput = Record<never, string>,
+  TSlots extends readonly Slot[] = Slot[]
+> = {
+  meta: Required<
+    V2BuilderMeta<TMachine, TSelectorsOutput, TActionsOutput, TSlots> & {
+      builderVersion: 2;
+    }
+  >;
+};

--- a/src/useService.ts
+++ b/src/useService.ts
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { EventObject, Interpreter, InterpreterFrom, AnyState } from "xstate";
 
-import { AnyXstateTreeMachine, XstateTreeMachineStateSchema } from "./types";
+import { AnyXstateTreeMachine, XstateTreeMachineStateSchemaV1 } from "./types";
 import { isEqual } from "./utils";
 
 /**
@@ -116,7 +116,7 @@ export function useService<
     current,
     children as unknown as Map<
       string | number,
-      Interpreter<any, XstateTreeMachineStateSchema<any, any, any>, any, any>
+      Interpreter<any, XstateTreeMachineStateSchemaV1<any, any, any>, any, any>
     >,
   ] as const;
 }

--- a/xstate-tree.api.md
+++ b/xstate-tree.api.md
@@ -25,6 +25,12 @@ import { TypegenDisabled } from 'xstate';
 import * as Z from 'zod';
 
 // @public (undocumented)
+export type Actions<TMachine extends AnyStateMachine, TSelectorsOutput, TOut> = (args: {
+    send: InterpreterFrom<TMachine>["send"];
+    selectors: TSelectorsOutput;
+}) => TOut;
+
+// @public (undocumented)
 export type AnyActions = (send: any, selectors: any) => any;
 
 // @public (undocumented)
@@ -45,10 +51,10 @@ export type AnyRoute = {
 };
 
 // @public (undocumented)
-export type AnySelector = Selectors<any, any, any, any>;
+export type AnySelector = V1Selectors<any, any, any, any>;
 
 // @public (undocumented)
-export type AnyXstateTreeMachine = StateMachine<any, XstateTreeMachineStateSchema<AnyStateMachine, any, any>, any>;
+export type AnyXstateTreeMachine = StateMachine<any, XstateTreeMachineStateSchemaV1<AnyStateMachine, AnySelector, AnyActions> | XstateTreeMachineStateSchemaV2<AnyStateMachine, any, any>, any>;
 
 // @public (undocumented)
 export type ArgumentsForRoute<T> = T extends Route<infer TParams, infer TQuery, any, infer TMeta> ? RouteArguments<TParams, TQuery, TMeta> : never;
@@ -56,7 +62,7 @@ export type ArgumentsForRoute<T> = T extends Route<infer TParams, infer TQuery, 
 // @public
 export function broadcast(event: GlobalEvents): void;
 
-// @public
+// @public @deprecated
 export function buildActions<TMachine extends AnyStateMachine, TActions, TSelectors, TSend = InterpreterFrom<TMachine>["send"]>(__machine: TMachine, __selectors: TSelectors, actions: (send: TSend, selectors: OutputFromSelector<TSelectors>) => TActions): (send: TSend, selectors: OutputFromSelector<TSelectors>) => TActions;
 
 // @public
@@ -110,14 +116,14 @@ export function buildRootComponent(machine: AnyXstateTreeMachine, routing?: {
     rootMachine: AnyXstateTreeMachine;
 };
 
-// Warning: (ae-forgotten-export) The symbol "CanHandleEvent" needs to be exported by the entry point index.d.ts
+// Warning: (ae-incompatible-release-tags) The symbol "buildSelectors" is marked as @public, but its signature references "CanHandleEvent" which is marked as @internal
 // Warning: (ae-incompatible-release-tags) The symbol "buildSelectors" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal
 //
-// @public
-export function buildSelectors<TMachine extends AnyStateMachine, TSelectors, TContext = ContextFrom<TMachine>>(__machine: TMachine, selectors: (ctx: TContext, canHandleEvent: CanHandleEvent<TMachine>, inState: MatchesFrom<TMachine>, __currentState: never) => TSelectors): Selectors<TContext, EventFrom<TMachine>, TSelectors, MatchesFrom<TMachine>>;
+// @public @deprecated
+export function buildSelectors<TMachine extends AnyStateMachine, TSelectors, TContext = ContextFrom<TMachine>>(__machine: TMachine, selectors: (ctx: TContext, canHandleEvent: CanHandleEvent<TMachine>, inState: MatchesFrom<TMachine>, __currentState: never) => TSelectors): V1Selectors<TContext, EventFrom<TMachine>, TSelectors, MatchesFrom<TMachine>>;
 
 // @public
-export function buildTestRootComponent<TMachine extends AnyStateMachine, TSelectors extends AnySelector, TActions extends AnyActions, TContext = ContextFrom<TMachine>>(machine: StateMachine<TContext, XstateTreeMachineStateSchema<TMachine, TSelectors, TActions>, EventFrom<TMachine>>, logger: typeof console.log): {
+export function buildTestRootComponent<TMachine extends AnyStateMachine, TSelectors extends AnySelector, TActions extends AnyActions, TContext = ContextFrom<TMachine>>(machine: StateMachine<TContext, XstateTreeMachineStateSchemaV1<TMachine, TSelectors, TActions>, EventFrom<TMachine>>, logger: typeof console.log): {
     rootComponent: () => JSX.Element | null;
     addTransitionListener: (listener: () => void) => void;
     awaitTransition(): Promise<void>;
@@ -125,7 +131,7 @@ export function buildTestRootComponent<TMachine extends AnyStateMachine, TSelect
 
 // Warning: (ae-incompatible-release-tags) The symbol "buildView" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal
 //
-// @public
+// @public @deprecated
 export function buildView<TMachine extends AnyStateMachine, TEvent extends EventObject, TActions, TSelectors extends AnySelector, TSlots extends readonly Slot[] = [], TMatches extends AnyFunction = MatchesFrom<TMachine>, TViewProps = ViewProps<OutputFromSelector<TSelectors>, TActions, TSlots, TMatches>, TSend = (send: TEvent) => void>(__machine: TMachine, __selectors: TSelectors, __actions: (send: TSend, selectors: OutputFromSelector<TSelectors>) => TActions, __slots: TSlots, view: React_2.ComponentType<TViewProps>): React_2.ComponentType<TViewProps>;
 
 // Warning: (ae-forgotten-export) The symbol "InferViewProps" needs to be exported by the entry point index.d.ts
@@ -134,8 +140,16 @@ export function buildView<TMachine extends AnyStateMachine, TEvent extends Event
 // @public
 export function buildViewProps<C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>>(_view: C, props: Pick<InferViewProps<PropsOf<C>>, "actions" | "selectors">): InferViewProps<PropsOf<C>>;
 
+// @public @deprecated
+export function buildXStateTreeMachine<TMachine extends AnyStateMachine, TSelectors extends AnySelector, TActions extends AnyActions>(machine: TMachine, meta: XStateTreeMachineMetaV1<TMachine, TSelectors, TActions>): StateMachine<ContextFrom<TMachine>, XstateTreeMachineStateSchemaV1<TMachine, TSelectors, TActions>, EventFrom<TMachine>, any, any, any, any>;
+
+// Warning: (ae-internal-missing-underscore) The name "CanHandleEvent" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export type CanHandleEvent<TMachine extends AnyStateMachine> = (e: EventFrom<TMachine>) => boolean;
+
 // @public
-export function buildXStateTreeMachine<TMachine extends AnyStateMachine, TSelectors extends AnySelector, TActions extends AnyActions>(machine: TMachine, meta: XStateTreeMachineMeta<TMachine, TSelectors, TActions>): StateMachine<ContextFrom<TMachine>, XstateTreeMachineStateSchema<TMachine, TSelectors, TActions>, EventFrom<TMachine>, any, any, any, any>;
+export function createXStateTreeMachine<TMachine extends AnyStateMachine, TSelectorsOutput = ContextFrom<TMachine>, TActionsOutput = Record<never, string>, TSlots extends readonly Slot[] = []>(machine: TMachine, options: V2BuilderMeta<TMachine, TSelectorsOutput, TActionsOutput, TSlots>): StateMachine<ContextFrom<TMachine>, XstateTreeMachineStateSchemaV2<TMachine, TSelectorsOutput, TActionsOutput, TSlots>, EventFrom<TMachine>, any, any, any, any>;
 
 // @public
 export const genericSlotsTestingDummy: any;
@@ -208,7 +222,7 @@ export function multiSlot<T extends string>(name: T): MultiSlot<T>;
 export function onBroadcast(handler: (event: GlobalEvents) => void): () => void;
 
 // @public (undocumented)
-export type OutputFromSelector<T> = T extends Selectors<any, any, infer O, any> ? O : never;
+export type OutputFromSelector<T> = T extends V1Selectors<any, any, infer O, any> ? O : never;
 
 // @public
 export type Params<T> = T extends {
@@ -302,7 +316,11 @@ export type RoutingEvent<T> = T extends Route<infer TParams, infer TQuery, infer
 } : never;
 
 // @public (undocumented)
-export type Selectors<TContext, TEvent, TSelectors, TMatches> = (ctx: TContext, canHandleEvent: (e: TEvent) => boolean, inState: TMatches, __currentState: never) => TSelectors;
+export type Selectors<TMachine extends AnyStateMachine, TOut> = (args: {
+    ctx: ContextFrom<TMachine>;
+    canHandleEvent: CanHandleEvent<TMachine>;
+    inState: MatchesFrom<TMachine>;
+}) => TOut;
 
 // @public (undocumented)
 export type SharedMeta = {
@@ -326,7 +344,7 @@ export function singleSlot<T extends string>(name: T): SingleSlot<T>;
 export type Slot = SingleSlot<any> | MultiSlot<any>;
 
 // @public
-export function slotTestingDummyFactory(name: string): StateMachine<unknown, XstateTreeMachineStateSchema<StateMachine<unknown, any, AnyEventObject, {
+export function slotTestingDummyFactory(name: string): StateMachine<unknown, XstateTreeMachineStateSchemaV1<StateMachine<unknown, any, AnyEventObject, {
     value: any;
     context: unknown;
 }, BaseActionObject, ServiceMap, ResolveTypegenMeta<TypegenDisabled, AnyEventObject, BaseActionObject, ServiceMap>>, () => {}, () => {}>, AnyEventObject, any, any, any, any>;
@@ -343,6 +361,24 @@ export enum SlotType {
 export type StyledLink<TStyleProps = {}> = <TRoute extends AnyRoute>(props: LinkProps<TRoute> & TStyleProps) => JSX.Element;
 
 // @public (undocumented)
+export type V1Selectors<TContext, TEvent, TSelectors, TMatches> = (ctx: TContext, canHandleEvent: (e: TEvent) => boolean, inState: TMatches, __currentState: never) => TSelectors;
+
+// @public (undocumented)
+export type V2BuilderMeta<TMachine extends AnyStateMachine, TSelectorsOutput = ContextFrom<TMachine>, TActionsOutput = Record<never, string>, TSlots extends readonly Slot[] = Slot[]> = {
+    selectors?: Selectors<TMachine, TSelectorsOutput>;
+    actions?: Actions<TMachine, TSelectorsOutput, TActionsOutput>;
+    slots?: TSlots;
+    view: View<TActionsOutput, TSelectorsOutput, TSlots>;
+};
+
+// @public (undocumented)
+export type View<TActionsOutput, TSelectorsOutput, TSlots extends readonly Slot[]> = React_2.ComponentType<{
+    slots: Record<GetSlotNames<TSlots>, React_2.ComponentType>;
+    actions: TActionsOutput;
+    selectors: TSelectorsOutput;
+}>;
+
+// @public (undocumented)
 export type ViewProps<TSelectors, TActions, TSlots extends readonly Slot[], TMatches extends AnyFunction> = {
     slots: Record<GetSlotNames<TSlots>, React_2.ComponentType>;
     actions: TActions;
@@ -357,7 +393,7 @@ export type XstateTreeHistory<T = unknown> = History_2<{
 }>;
 
 // @public (undocumented)
-export type XStateTreeMachineMeta<TMachine extends AnyStateMachine, TSelectors, TActions extends AnyActions, TSlots extends readonly Slot[] = Slot[]> = {
+export type XStateTreeMachineMetaV1<TMachine extends AnyStateMachine, TSelectors, TActions extends AnyActions, TSlots extends readonly Slot[] = Slot[]> = {
     slots: TSlots;
     view: React_2.ComponentType<ViewProps<OutputFromSelector<TSelectors>, ReturnType<TActions>, TSlots, MatchesFrom<TMachine>>>;
     selectors: TSelectors;
@@ -366,8 +402,17 @@ export type XStateTreeMachineMeta<TMachine extends AnyStateMachine, TSelectors, 
 };
 
 // @public (undocumented)
-export type XstateTreeMachineStateSchema<TMachine extends AnyStateMachine, TSelectors extends AnySelector, TActions extends AnyActions> = {
-    meta: XStateTreeMachineMeta<TMachine, TSelectors, TActions>;
+export type XstateTreeMachineStateSchemaV1<TMachine extends AnyStateMachine, TSelectors extends AnySelector, TActions extends AnyActions> = {
+    meta: XStateTreeMachineMetaV1<TMachine, TSelectors, TActions> & {
+        builderVersion: 1;
+    };
+};
+
+// @public (undocumented)
+export type XstateTreeMachineStateSchemaV2<TMachine extends AnyStateMachine, TSelectorsOutput = ContextFrom<TMachine>, TActionsOutput = Record<never, string>, TSlots extends readonly Slot[] = Slot[]> = {
+    meta: Required<V2BuilderMeta<TMachine, TSelectorsOutput, TActionsOutput, TSlots> & {
+        builderVersion: 2;
+    }>;
 };
 
 // Warnings were encountered during analysis:
@@ -375,7 +420,9 @@ export type XstateTreeMachineStateSchema<TMachine extends AnyStateMachine, TSele
 // src/routing/createRoute/createRoute.ts:265:78 - (ae-forgotten-export) The symbol "MergeRouteTypes" needs to be exported by the entry point index.d.ts
 // src/routing/createRoute/createRoute.ts:265:78 - (ae-forgotten-export) The symbol "ResolveZodType" needs to be exported by the entry point index.d.ts
 // src/routing/createRoute/createRoute.ts:301:9 - (ae-forgotten-export) The symbol "RouteRedirect" needs to be exported by the entry point index.d.ts
-// src/types.ts:22:3 - (ae-incompatible-release-tags) The symbol "view" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal
+// src/types.ts:25:3 - (ae-incompatible-release-tags) The symbol "view" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal
+// src/types.ts:172:3 - (ae-incompatible-release-tags) The symbol "canHandleEvent" is marked as @public, but its signature references "CanHandleEvent" which is marked as @internal
+// src/types.ts:173:3 - (ae-incompatible-release-tags) The symbol "inState" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 


### PR DESCRIPTION
This implements https://github.com/koordinates/xstate-tree/issues/14 xstate-tree machine building 2.0

A new single builder function for constructing xstate-tree machines, createXStateTreeMachine, has been created
which replaces the previous build* functions, which have been deprecated.

This function provides better UX by eliminating the boilerplate of having to use 4 separate builder functions
and allowing the omitting of selector/action/slots arguements for machines that do not need them. Providing the context
object via the selectors by default.

Closes #14 