### PR TITLE
feat(routing): history argument is now a function 

### DIFF
--- a/examples/todomvc/routes.ts
+++ b/examples/todomvc/routes.ts
@@ -2,7 +2,7 @@ import { buildCreateRoute, XstateTreeHistory } from "@koordinates/xstate-tree";
 import { createBrowserHistory } from "history";
 
 export const history: XstateTreeHistory = createBrowserHistory();
-const createRoute = buildCreateRoute(history, "/");
+const createRoute = buildCreateRoute(() => history, "/");
 
 export const allTodos = createRoute.simpleRoute()({
   url: "/",

--- a/src/routing/createRoute/createRoute.spec.ts
+++ b/src/routing/createRoute/createRoute.spec.ts
@@ -7,7 +7,7 @@ import { assert } from "../../utils";
 import { buildCreateRoute } from "./createRoute";
 
 const hist = createMemoryHistory<{ meta?: unknown }>();
-const createRoute = buildCreateRoute(hist, "/");
+const createRoute = buildCreateRoute(() => hist, "/");
 
 describe("createRoute", () => {
   describe("createRoute.dynamicRoute", () => {
@@ -56,7 +56,7 @@ describe("createRoute", () => {
       const route = createRoute.simpleRoute()({ url: "/foo", event: "GO_FOO" });
 
       expect(route.basePath).toBe("/");
-      expect(route.history).toBe(hist);
+      expect(route.history()).toBe(hist);
     });
 
     describe("route schemas", () => {
@@ -313,7 +313,7 @@ describe("createRoute", () => {
         const hist: XstateTreeHistory = createMemoryHistory();
         const spy = jest.fn();
         hist.push = spy as any;
-        const createRoute = buildCreateRoute(hist, "/");
+        const createRoute = buildCreateRoute(() => hist, "/");
         const route = createRoute.simpleRoute()({
           url: "/foo/:fooId",
           event: "GO_FOO",
@@ -335,7 +335,7 @@ describe("createRoute", () => {
         const hist: XstateTreeHistory = createMemoryHistory();
         const spy = jest.fn();
         hist.replace = spy as any;
-        const createRoute = buildCreateRoute(hist, "/");
+        const createRoute = buildCreateRoute(() => hist, "/");
         const route = createRoute.simpleRoute()({
           url: "/foo/:fooId",
           event: "GO_FOO",

--- a/src/routing/createRoute/createRoute.ts
+++ b/src/routing/createRoute/createRoute.ts
@@ -148,7 +148,7 @@ export type Route<TParams, TQuery, TEvent, TMeta> = {
    * Event type for this route
    */
   event: TEvent;
-  history: XstateTreeHistory;
+  history: () => XstateTreeHistory;
   basePath: string;
   parent?: AnyRoute;
   paramsSchema?: Z.ZodObject<any>;
@@ -166,7 +166,7 @@ export type AnyRoute = {
   getEvent: any;
   event: string;
   basePath: string;
-  history: XstateTreeHistory;
+  history: () => XstateTreeHistory;
   parent?: AnyRoute;
   paramsSchema?: Z.ZodObject<any>;
   querySchema?: Z.ZodObject<any>;
@@ -262,7 +262,10 @@ type ResolveZodType<T extends Z.ZodType<any> | undefined> = undefined extends T
  * @param history - the history object to use for this route factory, this needs to be the same one used in the trees root component
  * @param basePath - the base path for this route factory
  */
-export function buildCreateRoute(history: XstateTreeHistory, basePath: string) {
+export function buildCreateRoute(
+  history: () => XstateTreeHistory,
+  basePath: string
+) {
   function navigate({
     history,
     url,
@@ -535,7 +538,7 @@ export function buildCreateRoute(history: XstateTreeHistory, basePath: string) {
             navigate({
               url: joinRoutes(this.basePath, url),
               meta,
-              history: this.history,
+              history: this.history(),
             });
           },
         };

--- a/src/routing/handleLocationChange/handleLocationChange.spec.ts
+++ b/src/routing/handleLocationChange/handleLocationChange.spec.ts
@@ -7,7 +7,8 @@ import { RoutingEvent } from "../routingEvent";
 
 import { handleLocationChange, Routing404Event } from "./handleLocationChange";
 
-const createRoute = buildCreateRoute(createMemoryHistory(), "/");
+const hist = createMemoryHistory<{ meta?: unknown }>();
+const createRoute = buildCreateRoute(() => hist, "/");
 const foo = createRoute.simpleRoute()({ url: "/foo", event: "GO_FOO" });
 const bar = createRoute.simpleRoute(foo)({ url: "/bar", event: "GO_BAR" });
 const routes = [foo, bar];

--- a/src/routing/matchRoute/matchRoute.spec.ts
+++ b/src/routing/matchRoute/matchRoute.spec.ts
@@ -6,7 +6,7 @@ import { buildCreateRoute } from "../createRoute";
 import { matchRoute } from "./matchRoute";
 
 const hist = createMemoryHistory<{ meta?: unknown }>();
-const createRoute = buildCreateRoute(hist, "/");
+const createRoute = buildCreateRoute(() => hist, "/");
 describe("matchRoute", () => {
   const route1 = createRoute.simpleRoute()({ url: "/route1", event: "ROUTE_1" });
   const route2 = createRoute.simpleRoute()({

--- a/src/routing/useHref.spec.ts
+++ b/src/routing/useHref.spec.ts
@@ -5,7 +5,7 @@ import { buildCreateRoute } from "./createRoute";
 import { useHref } from "./useHref";
 
 const hist = createMemoryHistory<{ meta?: unknown }>();
-const createRoute = buildCreateRoute(hist, "/foo");
+const createRoute = buildCreateRoute(() => hist, "/foo");
 const route = createRoute.simpleRoute()({
   url: "/bar/:type(valid)",
   event: "GO_BAR",

--- a/src/test-app/routes.ts
+++ b/src/test-app/routes.ts
@@ -3,7 +3,7 @@ import { createMemoryHistory } from "history";
 import { buildCreateRoute } from "../routing";
 
 export const history = createMemoryHistory<any>();
-const createRoute = buildCreateRoute(history, "/");
+const createRoute = buildCreateRoute(() => history, "/");
 export const homeRoute = createRoute.route()({
   matcher(url, _query) {
     if (url === "/") {

--- a/src/tests/asyncRouteRedirects.spec.tsx
+++ b/src/tests/asyncRouteRedirects.spec.tsx
@@ -18,7 +18,7 @@ import { delay } from "../utils";
 
 describe("async route redirects", () => {
   const hist: XstateTreeHistory = createMemoryHistory();
-  const createRoute = buildCreateRoute(hist, "/");
+  const createRoute = buildCreateRoute(() => hist, "/");
 
   const parentRoute = createRoute.simpleRoute()({
     url: "/:notFoo/",

--- a/xstate-tree.api.md
+++ b/xstate-tree.api.md
@@ -41,7 +41,7 @@ export type AnyRoute = {
     getEvent: any;
     event: string;
     basePath: string;
-    history: XstateTreeHistory;
+    history: () => XstateTreeHistory;
     parent?: AnyRoute;
     paramsSchema?: Z.ZodObject<any>;
     querySchema?: Z.ZodObject<any>;
@@ -66,7 +66,7 @@ export function broadcast(event: GlobalEvents): void;
 export function buildActions<TMachine extends AnyStateMachine, TActions, TSelectors, TSend = InterpreterFrom<TMachine>["send"]>(__machine: TMachine, __selectors: TSelectors, actions: (send: TSend, selectors: OutputFromSelector<TSelectors>) => TActions): (send: TSend, selectors: OutputFromSelector<TSelectors>) => TActions;
 
 // @public
-export function buildCreateRoute(history: XstateTreeHistory, basePath: string): {
+export function buildCreateRoute(history: () => XstateTreeHistory, basePath: string): {
     simpleRoute<TBaseRoute extends AnyRoute>(baseRoute?: TBaseRoute | undefined): <TEvent extends string, TParamsSchema extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
         [x: string]: any;
     }, {
@@ -257,7 +257,7 @@ export type Route<TParams, TQuery, TEvent, TMeta> = {
     }) | false;
     reverser: RouteArgumentFunctions<string, TParams, TQuery, TMeta>;
     event: TEvent;
-    history: XstateTreeHistory;
+    history: () => XstateTreeHistory;
     basePath: string;
     parent?: AnyRoute;
     paramsSchema?: Z.ZodObject<any>;
@@ -417,9 +417,9 @@ export type XstateTreeMachineStateSchemaV2<TMachine extends AnyStateMachine, TSe
 
 // Warnings were encountered during analysis:
 //
-// src/routing/createRoute/createRoute.ts:265:78 - (ae-forgotten-export) The symbol "MergeRouteTypes" needs to be exported by the entry point index.d.ts
-// src/routing/createRoute/createRoute.ts:265:78 - (ae-forgotten-export) The symbol "ResolveZodType" needs to be exported by the entry point index.d.ts
-// src/routing/createRoute/createRoute.ts:301:9 - (ae-forgotten-export) The symbol "RouteRedirect" needs to be exported by the entry point index.d.ts
+// src/routing/createRoute/createRoute.ts:267:19 - (ae-forgotten-export) The symbol "MergeRouteTypes" needs to be exported by the entry point index.d.ts
+// src/routing/createRoute/createRoute.ts:267:19 - (ae-forgotten-export) The symbol "ResolveZodType" needs to be exported by the entry point index.d.ts
+// src/routing/createRoute/createRoute.ts:304:9 - (ae-forgotten-export) The symbol "RouteRedirect" needs to be exported by the entry point index.d.ts
 // src/types.ts:25:3 - (ae-incompatible-release-tags) The symbol "view" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal
 // src/types.ts:172:3 - (ae-incompatible-release-tags) The symbol "canHandleEvent" is marked as @public, but its signature references "CanHandleEvent" which is marked as @internal
 // src/types.ts:173:3 - (ae-incompatible-release-tags) The symbol "inState" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal


### PR DESCRIPTION
Instead of passing the history argument to `buildCreateRoute` directly, it is now a function that returns the history object.

This is to solve an internal issue with the Koordinates codebase