### PR TITLE
fix(builders): v2 builder view triggering rule of hooks

### DIFF
--- a/examples/todomvc/App.tsx
+++ b/examples/todomvc/App.tsx
@@ -150,7 +150,7 @@ export const TodoApp = createXStateTreeMachine(machine, {
     };
   },
   slots: [TodosSlot],
-  view({ actions, selectors, slots }) {
+  View({ actions, selectors, slots }) {
     return (
       <>
         <section className="todoapp">

--- a/examples/todomvc/Todo.tsx
+++ b/examples/todomvc/Todo.tsx
@@ -182,7 +182,7 @@ export const TodoMachine = createXStateTreeMachine(machine, {
       },
     };
   },
-  view({
+  View({
     selectors: { completed, editedText, text, editing, viewing },
     actions,
   }) {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -245,7 +245,7 @@ export function createXStateTreeMachine<
   const xstateTreeMeta = {
     selectors,
     actions,
-    view: options.view,
+    View: options.View,
     slots: options.slots ?? [],
   };
   machine.meta = {

--- a/src/test-app/AppMachine.tsx
+++ b/src/test-app/AppMachine.tsx
@@ -69,8 +69,7 @@ export const BuiltAppMachine = createXStateTreeMachine(AppMachine, {
       showingOtherScreen: inState("otherScreen"),
     };
   },
-  view({ slots, selectors }) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
+  View({ slots, selectors }) {
     const isHomeActive = useIsRouteActive(homeRoute);
 
     return (

--- a/src/test-app/OtherMachine.tsx
+++ b/src/test-app/OtherMachine.tsx
@@ -47,7 +47,7 @@ export const OtherMachine = createXStateTreeMachine(machine, {
       canDoTheThing: canHandleEvent({ type: "DO_THE_THING" }),
     };
   },
-  view({ selectors }) {
+  View({ selectors }) {
     return (
       <>
         <p data-testid="can-do-the-thing">

--- a/src/test-app/TodoMachine.tsx
+++ b/src/test-app/TodoMachine.tsx
@@ -160,7 +160,7 @@ const BoundTodoMachine = createXStateTreeMachine(TodoMachine, {
       },
     };
   },
-  view({ selectors, actions }) {
+  View({ selectors, actions }) {
     if (selectors.hidden) {
       return null;
     }

--- a/src/test-app/TodosMachine.tsx
+++ b/src/test-app/TodosMachine.tsx
@@ -209,7 +209,7 @@ const BuiltTodosMachine = createXStateTreeMachine(TodosMachine, {
       },
     };
   },
-  view({ slots, actions, selectors }) {
+  View({ slots, actions, selectors }) {
     if (selectors.loading) {
       return <p>Loading</p>;
     }

--- a/src/test-app/tests/itWorksWithoutRouting.integration.tsx
+++ b/src/test-app/tests/itWorksWithoutRouting.integration.tsx
@@ -16,7 +16,7 @@ const childMachine = createMachine({
 });
 
 const child = createXStateTreeMachine(childMachine, {
-  view: () => <p data-testid="child">child</p>,
+  View: () => <p data-testid="child">child</p>,
 });
 
 const childSlot = singleSlot("Child");
@@ -33,7 +33,7 @@ const rootMachine = createMachine<any, any, any>({
 
 const root = createXStateTreeMachine(rootMachine, {
   slots: [childSlot],
-  view({ slots }) {
+  View({ slots }) {
     return (
       <>
         <p data-testid="root">root</p>

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,7 +210,7 @@ export type V2BuilderMeta<
   selectors?: Selectors<TMachine, TSelectorsOutput>;
   actions?: Actions<TMachine, TSelectorsOutput, TActionsOutput>;
   slots?: TSlots;
-  view: View<TActionsOutput, TSelectorsOutput, TSlots>;
+  View: View<TActionsOutput, TSelectorsOutput, TSlots>;
 };
 
 /**

--- a/src/xstateTree.tsx
+++ b/src/xstateTree.tsx
@@ -264,7 +264,7 @@ export function XstateTreeView({ interpreter }: XStateTreeViewProps) {
         />
       );
     case 2:
-      const ViewV2 = interpreter.machine.meta!.view;
+      const ViewV2 = interpreter.machine.meta!.View;
       return (
         <ViewV2
           selectors={selectorsRef.current}
@@ -330,8 +330,17 @@ export function buildRootComponent(
   if (!machine.meta) {
     throw new Error("Root machine has no meta");
   }
-  if (!machine.meta.view) {
-    throw new Error("Root machine has no associated view");
+  switch (machine.meta.builderVersion) {
+    case 1:
+      if (!machine.meta.view) {
+        throw new Error("Root machine has no associated view");
+      }
+      break;
+    case 2:
+      if (!machine.meta.View) {
+        throw new Error("Root machine has no associated view");
+      }
+      break;
   }
 
   const RootComponent = function XstateTreeRootComponent() {

--- a/xstate-tree.api.md
+++ b/xstate-tree.api.md
@@ -374,7 +374,7 @@ export type V2BuilderMeta<TMachine extends AnyStateMachine, TSelectorsOutput = C
     selectors?: Selectors<TMachine, TSelectorsOutput>;
     actions?: Actions<TMachine, TSelectorsOutput, TActionsOutput>;
     slots?: TSlots;
-    view: View<TActionsOutput, TSelectorsOutput, TSlots>;
+    View: View<TActionsOutput, TSelectorsOutput, TSlots>;
 };
 
 // @public (undocumented)


### PR DESCRIPTION
The eslint React hook linting rules falsely generate errors in the view components because React components must start with an uppercase letter

So this renames the `view` field to `View` to satisfy the linter