### PR TITLE
fix(xstate-tree): canHandleEvent triggering side effects

### DIFF
--- a/src/xstateTree.tsx
+++ b/src/xstateTree.tsx
@@ -190,7 +190,7 @@ export function XstateTreeView({ interpreter }: XStateTreeViewProps) {
   );
   const canHandleEvent = useCallback(
     (e: AnyEventObject) => {
-      return interpreter.nextState(e).changed ?? false;
+      return interpreter.getSnapshot().can(e);
     },
     [interpreter]
   );


### PR DESCRIPTION
Due to the fact canHandleEvent just worked out the next state for an event and whether it had changed, the interpreter evaluates any assign actions associated with the event.

This results in any assign actions that cause side effects from being executed mistakenly.

Since `canHandleEvent` was originally created xstate has a new `state.can` method which is better suited for this and doesn't cause the assign actions to be executed.

So while you should not have side effects in your assign actions, if you do for some reason this won't trigger them when calling `canHandleEvent`