### PR TITLE
feat(routes): preloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@testing-library/dom": "^8.14.0",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^13.4.0",
-        "@testing-library/user-event": "^13.5.0",
+        "@testing-library/user-event": "^14.4.3",
         "@types/history": "^4.7.7",
         "@types/jest": "^28.1.4",
         "@types/react": "^17.0.29",
@@ -2850,15 +2850,12 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
       "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
@@ -20685,13 +20682,11 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
       "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5"
-      }
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@testing-library/dom": "^8.14.0",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/history": "^4.7.7",
     "@types/jest": "^28.1.4",
     "@types/react": "^17.0.29",

--- a/src/routing/Link.spec.tsx
+++ b/src/routing/Link.spec.tsx
@@ -1,0 +1,141 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryHistory } from "history";
+import React from "react";
+import { z } from "zod";
+
+import { delay } from "../utils";
+
+import { Link } from "./Link";
+import { buildCreateRoute } from "./createRoute";
+
+const hist = createMemoryHistory<{ meta?: unknown }>();
+const createRoute = buildCreateRoute(() => hist, "/");
+
+const route = createRoute.simpleRoute()({
+  event: "event",
+  url: "/url/:param",
+  paramsSchema: z.object({ param: z.string() }),
+});
+
+describe("Link", () => {
+  describe("preloading", () => {
+    it("calls the route preload on mouseDown if preloadOnInteraction is true", async () => {
+      route.preload = jest.fn();
+
+      const { getByText, rerender } = render(
+        <Link to={route} params={{ param: "test" }}>
+          Link
+        </Link>
+      );
+
+      await userEvent.click(getByText("Link"));
+      expect(route.preload).not.toHaveBeenCalled();
+
+      rerender(
+        <Link to={route} params={{ param: "test" }} preloadOnInteraction>
+          Link
+        </Link>
+      );
+
+      await userEvent.click(getByText("Link"));
+      expect(route.preload).toHaveBeenCalledWith({ params: { param: "test" } });
+    });
+
+    it("calls the route preload on hover if preloadOnHoverMs is set", async () => {
+      route.preload = jest.fn();
+
+      const { getByText, rerender } = render(
+        <Link to={route} params={{ param: "test" }}>
+          Link
+        </Link>
+      );
+
+      await userEvent.hover(getByText("Link"));
+      expect(route.preload).not.toHaveBeenCalled();
+
+      rerender(
+        <Link to={route} params={{ param: "test" }} preloadOnHoverMs={0}>
+          Link
+        </Link>
+      );
+
+      await userEvent.hover(getByText("Link"));
+      await delay(0);
+      expect(route.preload).toHaveBeenCalledWith({ params: { param: "test" } });
+    });
+
+    it("does not call the preload if the element isn't hovered for long enough", async () => {
+      route.preload = jest.fn();
+
+      const { getByText } = render(
+        <Link to={route} params={{ param: "test" }} preloadOnHoverMs={15}>
+          Link
+        </Link>
+      );
+
+      await userEvent.hover(getByText("Link"));
+      await delay(2);
+      await userEvent.unhover(getByText("Link"));
+
+      await delay(15);
+      expect(route.preload).not.toHaveBeenCalled();
+    });
+
+    it("calls user supplied onMouse Down/Enter/Leave when preloading is not active", async () => {
+      const onMouseDown = jest.fn();
+      const onMouseEnter = jest.fn();
+      const onMouseLeave = jest.fn();
+
+      const { getByText } = render(
+        <Link
+          to={route}
+          params={{ param: "test" }}
+          onMouseDown={onMouseDown}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        >
+          Link
+        </Link>
+      );
+
+      await userEvent.hover(getByText("Link"));
+      await userEvent.click(getByText("Link"));
+      await userEvent.unhover(getByText("Link"));
+
+      expect(onMouseDown).toHaveBeenCalledTimes(1);
+      expect(onMouseEnter).toHaveBeenCalledTimes(2);
+      expect(onMouseLeave).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls user supplied onMouse Down/Enter/Leave when preloading is active", async () => {
+      const onMouseDown = jest.fn();
+      const onMouseEnter = jest.fn();
+      const onMouseLeave = jest.fn();
+      route.preload = jest.fn();
+
+      const { getByText } = render(
+        <Link
+          to={route}
+          params={{ param: "test" }}
+          onMouseDown={onMouseDown}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          preloadOnHoverMs={0}
+          preloadOnInteraction
+        >
+          Link
+        </Link>
+      );
+
+      await userEvent.hover(getByText("Link"));
+      await userEvent.click(getByText("Link"));
+      await userEvent.unhover(getByText("Link"));
+
+      expect(onMouseDown).toHaveBeenCalledTimes(1);
+      expect(onMouseEnter).toHaveBeenCalledTimes(2);
+      expect(onMouseLeave).toHaveBeenCalledTimes(1);
+      expect(route.preload).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/src/routing/createRoute/createRoute.spec.ts
+++ b/src/routing/createRoute/createRoute.spec.ts
@@ -459,5 +459,40 @@ describe("createRoute", () => {
         route.navigate({ meta: { doNotNotifyReactRouter: true } });
       });
     });
+
+    describe("route preload functions", () => {
+      it("calls the route + parent route preload functions when preload is called", async () => {
+        const parentPreload = jest.fn();
+        const preload = jest.fn();
+
+        const parentRoute = createRoute.simpleRoute()({
+          url: "/foo/:fooParam/",
+          event: "GO_FOO",
+          paramsSchema: Z.object({
+            fooParam: Z.string(),
+          }),
+          preload: parentPreload,
+        });
+        const route = createRoute.simpleRoute(parentRoute)({
+          url: "/bar/:barParam",
+          event: "GO_BAR",
+          paramsSchema: Z.object({
+            barParam: Z.string(),
+          }),
+          preload,
+        });
+
+        const args = {
+          params: {
+            barParam: "123",
+            fooParam: "456",
+          },
+        };
+        route.preload(args);
+
+        expect(parentPreload).toHaveBeenCalledWith(args);
+        expect(preload).toHaveBeenCalledWith(args);
+      });
+    });
   });
 });

--- a/src/routing/handleLocationChange/handleLocationChange.spec.ts
+++ b/src/routing/handleLocationChange/handleLocationChange.spec.ts
@@ -1,4 +1,5 @@
 import { createMemoryHistory } from "history";
+import { z } from "zod";
 
 import { delay } from "../../utils";
 import { onBroadcast } from "../../xstateTree";
@@ -48,6 +49,26 @@ describe("handleLocationChange", () => {
 
     await delay(1);
     expect(broadcastEvents).toEqual([fooEvent]);
+  });
+
+  it("calls the route preload function if present", () => {
+    const preload = jest.fn();
+    const foo = createRoute.simpleRoute()({
+      url: "/foo/:bar",
+      event: "GO_FOO",
+      paramsSchema: z.object({ bar: z.string() }),
+      preload,
+    });
+
+    handleLocationChange([foo], "/", "/foo/bar", "", () => void 0);
+
+    expect(preload).toHaveBeenCalledWith({
+      params: { bar: "bar" },
+      query: {},
+      meta: {
+        indexEvent: true,
+      },
+    });
   });
 
   describe("route with parent route", () => {

--- a/src/routing/handleLocationChange/handleLocationChange.ts
+++ b/src/routing/handleLocationChange/handleLocationChange.ts
@@ -41,11 +41,12 @@ export function handleLocationChange(
     const matchedEvent = match.event;
     matchedEvent.meta = { ...(meta ?? {}) };
     (matchedEvent.meta as Record<any, any>).indexEvent = true;
-    const { params } = match.event;
+    const { params, query } = match.event;
 
     const routingEvents: any[] = [];
 
     let route: AnyRoute = match.route;
+    route.preload({ params, query, meta: matchedEvent.meta });
     while (route.parent) {
       routingEvents.push(
         route.parent.getEvent({ params, query: {}, meta: { ...(meta ?? {}) } })

--- a/src/tests/actionsGetUpdatedSelectors.spec.tsx
+++ b/src/tests/actionsGetUpdatedSelectors.spec.tsx
@@ -70,11 +70,11 @@ describe("actions accessing selectors", () => {
 
     const button = getByRole("button");
 
-    userEvent.click(button);
+    await userEvent.click(button);
     await delay();
     expect(button).toHaveTextContent("1");
 
-    userEvent.click(button);
+    await userEvent.click(button);
     await delay();
     expect(button).toHaveTextContent("2");
     expect(actionsCallCount).toBe(1);

--- a/xstate-tree.api.md
+++ b/xstate-tree.api.md
@@ -40,6 +40,7 @@ export type AnyRoute = {
     navigate: any;
     getEvent: any;
     event: string;
+    preload: any;
     basePath: string;
     history: () => XstateTreeHistory;
     parent?: AnyRoute;
@@ -82,6 +83,7 @@ export function buildCreateRoute(history: () => XstateTreeHistory, basePath: str
         querySchema?: TQuerySchema | undefined;
         meta?: TMeta | undefined;
         redirect?: RouteRedirect<MergeRouteTypes<RouteParams<TBaseRoute>, ResolveZodType<TParamsSchema>>, ResolveZodType<TQuerySchema>, MergeRouteTypes<RouteMeta<TBaseRoute>, TMeta> & SharedMeta> | undefined;
+        preload?: RouteArgumentFunctions<void, MergeRouteTypes<RouteParams<TBaseRoute>, ResolveZodType<TParamsSchema>>, ResolveZodType<TQuerySchema>, MergeRouteTypes<RouteMeta<TBaseRoute>, TMeta>, RouteArguments<MergeRouteTypes<RouteParams<TBaseRoute>, ResolveZodType<TParamsSchema>>, ResolveZodType<TQuerySchema>, MergeRouteTypes<RouteMeta<TBaseRoute>, TMeta>>> | undefined;
     }) => Route<MergeRouteTypes<RouteParams<TBaseRoute>, ResolveZodType<TParamsSchema>>, ResolveZodType<TQuerySchema>, TEvent, MergeRouteTypes<RouteMeta<TBaseRoute>, TMeta> & SharedMeta>;
     route<TBaseRoute_1 extends AnyRoute>(baseRoute?: TBaseRoute_1 | undefined): <TEvent_1 extends string, TParamsSchema_1 extends Z.ZodObject<any, "strip", Z.ZodTypeAny, {
         [x: string]: any;
@@ -91,7 +93,7 @@ export function buildCreateRoute(history: () => XstateTreeHistory, basePath: str
         [x: string]: any;
     }, {
         [x: string]: any;
-    }> | undefined, TMeta_1 extends Record<string, unknown>>({ event, matcher, reverser, paramsSchema, querySchema, redirect, }: {
+    }> | undefined, TMeta_1 extends Record<string, unknown>>({ event, matcher, reverser, paramsSchema, querySchema, redirect, preload, }: {
         event: TEvent_1;
         paramsSchema?: TParamsSchema_1 | undefined;
         querySchema?: TQuerySchema_1 | undefined;
@@ -101,6 +103,7 @@ export function buildCreateRoute(history: () => XstateTreeHistory, basePath: str
             matchLength: number;
         });
         reverser: RouteArgumentFunctions<string, MergeRouteTypes<RouteParams<TBaseRoute_1>, ResolveZodType<TParamsSchema_1>>, ResolveZodType<TQuerySchema_1>, MergeRouteTypes<RouteMeta<TBaseRoute_1>, TMeta_1>, RouteArguments<MergeRouteTypes<RouteParams<TBaseRoute_1>, ResolveZodType<TParamsSchema_1>>, ResolveZodType<TQuerySchema_1>, MergeRouteTypes<RouteMeta<TBaseRoute_1>, TMeta_1>>>;
+        preload?: RouteArgumentFunctions<void, MergeRouteTypes<RouteParams<TBaseRoute_1>, ResolveZodType<TParamsSchema_1>>, ResolveZodType<TQuerySchema_1>, MergeRouteTypes<RouteMeta<TBaseRoute_1>, TMeta_1>, RouteArguments<MergeRouteTypes<RouteParams<TBaseRoute_1>, ResolveZodType<TParamsSchema_1>>, ResolveZodType<TQuerySchema_1>, MergeRouteTypes<RouteMeta<TBaseRoute_1>, TMeta_1>>> | undefined;
     }) => Route<MergeRouteTypes<RouteParams<TBaseRoute_1>, ResolveZodType<TParamsSchema_1>>, ResolveZodType<TQuerySchema_1>, TEvent_1, MergeRouteTypes<RouteMeta<TBaseRoute_1>, TMeta_1> & SharedMeta>;
 };
 
@@ -175,7 +178,7 @@ export type GlobalEvents = {
 export function lazy<TMachine extends AnyStateMachine>(factory: () => Promise<TMachine>, { Loader, withContext, }?: Options<TMachine["context"]>): StateMachine<Context, any, Events, States, any, any, any>;
 
 // @public
-export function Link<TRoute extends AnyRoute>({ to, children, testId, ...rest }: LinkProps<TRoute>): JSX.Element;
+export function Link<TRoute extends AnyRoute>({ to, children, testId, preloadOnHoverMs, preloadOnInteraction, onMouseDown: _onMouseDown, onMouseEnter: _onMouseEnter, onMouseLeave: _onMouseLeave, ...rest }: LinkProps<TRoute>): JSX.Element;
 
 // @public (undocumented)
 export type LinkProps<TRoute extends AnyRoute, TRouteParams = TRoute extends Route<infer TParams, any, any, any> ? TParams : undefined, TRouteQuery = TRoute extends Route<any, infer TQuery, any, any> ? TQuery : undefined, TRouteMeta = TRoute extends Route<any, any, any, infer TMeta> ? TMeta : undefined> = {
@@ -183,6 +186,8 @@ export type LinkProps<TRoute extends AnyRoute, TRouteParams = TRoute extends Rou
     children: React_2.ReactNode;
     testId?: string;
     onClick?: (e: React_2.MouseEvent<HTMLAnchorElement>) => boolean | void;
+    preloadOnInteraction?: boolean;
+    preloadOnHoverMs?: number;
 } & RouteArguments<TRouteParams, TRouteQuery, TRouteMeta> & Omit<React_2.AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "onClick">;
 
 // @public (undocumented)
@@ -249,6 +254,7 @@ export type Route<TParams, TQuery, TEvent, TMeta> = {
     } & RouteArguments<TParams, TQuery, TMeta>) | false;
     reverse: RouteArgumentFunctions<string, TParams, TQuery, undefined>;
     navigate: RouteArgumentFunctions<void, TParams, TQuery, TMeta>;
+    preload: RouteArgumentFunctions<void, TParams, TQuery, TMeta>;
     getEvent: RouteArgumentFunctions<{
         type: TEvent;
     } & RouteArguments<TParams, TQuery, TMeta>, TParams, TQuery, TMeta>;
@@ -429,9 +435,9 @@ export type XstateTreeMachineStateSchemaV2<TMachine extends AnyStateMachine, TSe
 
 // Warnings were encountered during analysis:
 //
-// src/routing/createRoute/createRoute.ts:267:19 - (ae-forgotten-export) The symbol "MergeRouteTypes" needs to be exported by the entry point index.d.ts
-// src/routing/createRoute/createRoute.ts:267:19 - (ae-forgotten-export) The symbol "ResolveZodType" needs to be exported by the entry point index.d.ts
-// src/routing/createRoute/createRoute.ts:304:9 - (ae-forgotten-export) The symbol "RouteRedirect" needs to be exported by the entry point index.d.ts
+// src/routing/createRoute/createRoute.ts:279:19 - (ae-forgotten-export) The symbol "MergeRouteTypes" needs to be exported by the entry point index.d.ts
+// src/routing/createRoute/createRoute.ts:279:19 - (ae-forgotten-export) The symbol "ResolveZodType" needs to be exported by the entry point index.d.ts
+// src/routing/createRoute/createRoute.ts:316:9 - (ae-forgotten-export) The symbol "RouteRedirect" needs to be exported by the entry point index.d.ts
 // src/types.ts:25:3 - (ae-incompatible-release-tags) The symbol "view" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal
 // src/types.ts:172:3 - (ae-incompatible-release-tags) The symbol "canHandleEvent" is marked as @public, but its signature references "CanHandleEvent" which is marked as @internal
 // src/types.ts:173:3 - (ae-incompatible-release-tags) The symbol "inState" is marked as @public, but its signature references "MatchesFrom" which is marked as @internal


### PR DESCRIPTION
Adds a preload function to a route, this is an optional idempotency-required function that can be used to kick off data preloading for a route before it has been matched

The function can be called automatically by links on click or hover, and when a route is matched right before it's broadcast